### PR TITLE
Don't append target to body if target option is given

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@ import {getQueriesForElement, prettyDOM} from 'dom-testing-library'
 
 export * from 'dom-testing-library'
 const mountedContainers = new Set()
-export const render = (Component, {target = document.createElement('div'), ...options} = {}) => {
-  document.body.appendChild(target)
+export const render = (Component, {target, ...options} = {}) => {
+  if (!target) {
+    target = document.body.appendChild(document.createElement('div'))
+  }
 
   const component = new Component({
     ...options,


### PR DESCRIPTION
The `target` is always appended to the DOM, regardless if the user supplied a `target` option or not. This PR makes it so we don't add it to the body if `target` is set.