### PR TITLE
fix: Moved dom-testing-library as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.3",
     "core-js": "^3.0.1",
-    "dom-testing-library": "^4.0.0",
+    "dom-testing-library": "^4.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "babel-jest": "^24.7.1",
     "deasync": "^0.1.14",
-    "dom-testing-library": "^4.0.0",
     "esm": "^3.2.22",
     "jest": "^24.7.1",
     "jest-dom": "^3.1.2",
@@ -42,7 +41,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "core-js": "^3.0.1"
+    "core-js": "^3.0.1",
+    "dom-testing-library": "^4.0.0",
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
Fixes #21 