### PR TITLE
Remove broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ practices.</p>
 - [This solution](#this-solution)
 - [Example](#example)
 - [Installation](#installation)
-- [Examples](#examples)
-- [Other Solutions](#other-solutions)
 - [Guiding Principles](#guiding-principles)
 - [Contributors](#contributors)
 - [Docs](#docs)


### PR DESCRIPTION
These sections were removed in 3acc235c72cb6a3e53c378e28c0f1ad7299de65c, this commit just removes them from the table of contents as well.