### PR TITLE
Check the default property of `Component` for the constructor

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ const config = Object.assign(jestConfig, {
   transform: {
     ...jestConfig.transform,
     '^.+\\.svelte$': 'jest-transform-svelte',
+    '^.+\\.html$': 'svelte-test/transform',
   },
   transformIgnorePatterns: [
     ...jestConfig.transformIgnorePatterns,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11517,6 +11517,15 @@
       "integrity": "sha512-b5TyzV7Dx1ijN4QPNarhKq5rX98QHDmi18nF0G8KV3d5KX3Jj98Yu4+tzM97ktnXcfoVJmvONvPaX1ZI0mr8Dw==",
       "dev": true
     },
+    "svelte-test": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/svelte-test/-/svelte-test-0.3.0.tgz",
+      "integrity": "sha512-aUdNJOOpvjWDXwvi7fGteo/eJWmAPa22VDxZH/OWv8/J4AVjUOLdkMoYf9MhaoWao5fzFM2vfdD+a17hUsb2LA==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.2.0"
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^4.0.4",
     "sirv-cli": "^0.4.0",
-    "svelte": "^3.0.0"
+    "svelte": "^3.0.0",
+    "svelte-test": "^0.3.0"
   },
   "peerDependencies": {
     "svelte": "3.x"

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ export const render = (Component, {target, ...options} = {}) => {
     target = document.body.appendChild(document.createElement('div'))
   }
 
-  const component = new Component({
+  const ComponentConstructor = Component.default || Component
+  const component = new ComponentConstructor({
     ...options,
     target,
   })

--- a/tests/example/App.html
+++ b/tests/example/App.html
@@ -1,0 +1,19 @@
+<script>
+	export let name;
+
+	let buttonText = "Button Text";
+
+	function handleClick() {
+	  buttonText = "Button Clicked";
+	}
+</script>
+
+<style>
+	h1 {
+	  color: purple;
+	}
+</style>
+
+<h1>Hello {name}!</h1>
+
+<button on:click={handleClick}>{buttonText}</button>

--- a/tests/render.spec.js
+++ b/tests/render.spec.js
@@ -7,6 +7,7 @@ import {
   prettyDOM,
 } from '../src'
 import App from './example/App.svelte'
+import App2 from './example/App.html'
 import 'jest-dom/extend-expect'
 
 afterEach(cleanup)
@@ -81,5 +82,11 @@ describe('render', () => {
     expect(container.innerHTML).toBe(document.body.innerHTML)
 
     cleanup()
+  })
+
+  test('correctly find component constructor on the default property', () => {
+    const {getByText} = render(App2, {props: {name: 'world'}})
+
+    expect(getByText('Hello world!')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
This change checks the default property of the `Component` argument in `render` to prevent problems mounting components due to the way that Svelte handles the presence of both named and default imports when compiling to `cjs`.

In order to test this I added another jest transform targetting `.html` files instead of `.svelte` files and used a jest transform that uses `svelte.compile` directly and compiles to `cjs`. An example `App.html` and a test rendering this file was also added.

Fixes #32.