### PR TITLE
Support cleanups on svelte v2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export const render = (Component, {target, ...options} = {}) => {
 const cleanupAtContainer = container => {
   const {target, component} = container
   
-  if (component.$destroy) {
+  if (typeof component.$destroy === 'function') {
     component.$destroy()
   } else {
     component.destroy()

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,13 @@ export const render = (Component, {target, ...options} = {}) => {
 
 const cleanupAtContainer = container => {
   const {target, component} = container
-  component.$destroy()
+  
+  if (component.$destroy) {
+    component.$destroy()
+  } else {
+    component.destroy()
+  }
+  
   /* istanbul ignore else  */
   if (target.parentNode === document.body) {
     document.body.removeChild(target)


### PR DESCRIPTION
On svelte version 2, the destroy method is named `component.destroy()`, not `component.$destroy()`.

I assume this library doesn't exactly support version 2, but I am currently trying it out to test svelte-v2 components and it's working quite well. The only issue I have with it so far is only this one, which has quite a simple fix.