### PR TITLE
feat: Add act

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export const cleanup = () => {
 
 export function act(fn) {
   const returnValue = fn()
-  if (returnValue != null && typeof returnValue.then === 'function') {
+  if (returnValue !== undefined && typeof returnValue.then === 'function') {
     return returnValue.then(() => tick())
   }
   return tick()

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {getQueriesForElement, prettyDOM} from '@testing-library/dom'
+import {tick} from 'svelte'
 
 export * from '@testing-library/dom'
 const mountedContainers = new Set()
@@ -35,4 +36,12 @@ const cleanupAtContainer = container => {
 
 export const cleanup = () => {
   mountedContainers.forEach(cleanupAtContainer)
+}
+
+export function act(fn) {
+  const returnValue = fn()
+  if (returnValue != null && typeof returnValue.then === 'function') {
+    return returnValue.then(() => tick())
+  }
+  return tick()
 }

--- a/tests/act.spec.js
+++ b/tests/act.spec.js
@@ -1,0 +1,35 @@
+import {act, render, fireEvent, cleanup} from '../src'
+import App from './example/App.svelte'
+import 'jest-dom/extend-expect'
+
+afterEach(cleanup)
+
+test('after awaited state updates are flushed', async () => {
+  const {getByText} = render(App, {props: {name: 'world'}})
+  const button = getByText('Button Text')
+
+  const acting = act(() => {
+    fireEvent.click(button)
+  })
+  expect(button).toHaveTextContent('Button Text')
+
+  await acting
+  expect(button).toHaveTextContent('Button Clicked')
+})
+
+test('accepts async functions', async () => {
+  function sleep(ms) {
+    return new Promise(resolve => {
+      setTimeout(() => resolve(), ms)
+    })
+  }
+
+  const {getByText} = render(App, {props: {name: 'world'}})
+  const button = getByText('Button Text')
+
+  await act(async () => {
+    await sleep(100)
+    fireEvent.click(button)
+  })
+  expect(button).toHaveTextContent('Button Clicked')
+})


### PR DESCRIPTION
Adds a function which can wrap testing actions and guarantees that after awaited state updates are flushed to the DOM.

Internal it just calls the callback and returns the promise from svelte's [`tick`](https://svelte.dev/docs#tick). This should replace the current documented approach of using `wait` + `expect` or `waitForElement`. The previous behavior either waited too long (default timeout of 2s) or was flaky if the timeout was really short. It's also slow when using `wait` since that uses polling.

It essentially mimics the [`act` from React](https://reactjs.org/docs/test-utils.html#act).