### PR TITLE
Fix example in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ describe("App", () => {
   test("should render greeting", () => {
     const { getByText } = render(App, { props: { name: "world" } });
 
-    expect(getByText("Hello world!"));
+    expect(getByText("Hello world!")).toBeInTheDocument();
   });
 
   test("should change button text after click", async () => {


### PR DESCRIPTION
I am junior in Svelte and completely not sure, that its example should be fixed at all. But Jest ESLint plugin has [recommended rule](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect.md) to show error on any `expect()` without matcher after it.

Should we add explicit matcher here? (Even if library hack `expect` we still need matcher for ESLint plugin)