### PR TITLE
style: remove warning comment above component from rendered results

### DIFF
--- a/src/pure.js
+++ b/src/pure.js
@@ -26,8 +26,6 @@ const render = (
 
   return {
     container,
-    // Only keeping this for backwards compatibility, this should not be used as it goes against
-    // the testing libraries 'Guiding Principles'. We should advise against its usage.
     component,
     debug: (el = container) => console.log(prettyDOM(el)),
     rerender: (options) => {


### PR DESCRIPTION
This is mostly in reference to #57. There are some use cases for testing with the component directly such as exported functions. The docs have also been updated accordingly.