### PR TITLE
Allow render to accept generics to type: Props, Events and Slots

### DIFF
--- a/src/pure.js
+++ b/src/pure.js
@@ -4,7 +4,7 @@ import { tick } from 'svelte'
 const containerCache = new Map()
 const componentCache = new Set()
 
-const svelteComponentOptions = ['anchor', 'props', 'hydrate', 'intro']
+const svelteComponentOptions = ['anchor', 'props', 'hydrate', 'intro', 'context']
 
 const render = (
   Component,

--- a/src/pure.js
+++ b/src/pure.js
@@ -4,7 +4,7 @@ import { tick } from 'svelte'
 const containerCache = new Map()
 const componentCache = new Set()
 
-const svleteComponentOptions = ['anchor', 'props', 'hydrate', 'intro']
+const svelteComponentOptions = ['anchor', 'props', 'hydrate', 'intro']
 
 const render = (
   Component,
@@ -17,19 +17,19 @@ const render = (
   const ComponentConstructor = Component.default || Component
 
   const checkProps = (options) => {
-    const isProps = !Object.keys(options).some(option => svleteComponentOptions.includes(option))
+    const isProps = !Object.keys(options).some(option => svelteComponentOptions.includes(option))
 
     // Check if any props and Svelte options were accidentally mixed.
     if (!isProps) {
       const unrecognizedOptions = Object
         .keys(options)
-        .filter(option => !svleteComponentOptions.includes(option))
+        .filter(option => !svelteComponentOptions.includes(option))
 
       if (unrecognizedOptions.length > 0) {
         throw Error(`
           Unknown options were found [${unrecognizedOptions}]. This might happen if you've mixed 
           passing in props with Svelte options into the render function. Valid Svelte options 
-          are [${svleteComponentOptions}]. You can either change the prop names, or pass in your 
+          are [${svelteComponentOptions}]. You can either change the prop names, or pass in your 
           props for that component via the \`props\` option.\n\n
           Eg: const { /** Results **/ } = render(MyComponent, { props: { /** props here **/ } })\n\n
         `)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,11 +3,18 @@
 // Definitions by: Rahim Alwer <https://github.com/mihar-22>
 
 import {queries, Queries, BoundFunction, EventType} from '@testing-library/dom'
-import { SvelteComponent } from 'svelte/types/runtime'
+import { SvelteComponentTyped } from 'svelte/types/runtime'
 
 export * from '@testing-library/dom'
 
-type SvelteComponentOptions = any
+export interface SvelteComponentOptions<P extends Record<string, any> = any>  {
+  target?: HTMLElement
+  anchor?: string
+  props?: P
+  context?: any
+  hydrate?: boolean
+  intro?: boolean
+}
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
@@ -16,7 +23,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
  */
 export type RenderResult<Q extends Queries = typeof queries> = {
   container: HTMLElement
-  component: SvelteComponent
+  component: SvelteComponentTyped
   debug: (el?: HTMLElement | DocumentFragment) => void
   rerender: (options: SvelteComponentOptions) => void
   unmount: () => void
@@ -28,16 +35,26 @@ export interface RenderOptions<Q extends Queries = typeof queries> {
 }
 
 export function render(
-  component: typeof SvelteComponent,
+  component: SvelteComponentTyped,
   componentOptions?: SvelteComponentOptions,
   renderOptions?: Omit<RenderOptions, 'queries'>
 ): RenderResult
 
 export function render<Q extends Queries>(
-  component: typeof SvelteComponent,
+  component: SvelteComponentTyped,
   componentOptions?: SvelteComponentOptions,
   renderOptions?: RenderOptions<Q>,
 ): RenderResult<Q>
+
+export function render<
+  P extends Record<string, any> = any,
+  E extends Record<string, any> = any,
+  S extends Record<string, any> = any
+>(
+  component: SvelteComponentTyped<P, E, S>,
+  componentOptions?: SvelteComponentOptions<P>,
+  renderOptions?: Omit<RenderOptions, "queries">
+): RenderResult;
 
 /**
  * Unmounts trees that were mounted with render.


### PR DESCRIPTION
Allow the render method to accept generics to type: Props, Events and Slots.

Added extended options as per https://svelte.dev/docs#Creating_a_component
- target
- anchor
- props 
- context
- hydrate
- intro

