### PR TITLE
feat: set svelte context in render fn

### DIFF
--- a/src/pure.js
+++ b/src/pure.js
@@ -4,7 +4,7 @@ import { tick } from 'svelte'
 const containerCache = new Map()
 const componentCache = new Set()
 
-const svleteComponentOptions = ['anchor', 'props', 'hydrate', 'intro']
+const svleteComponentOptions = ['anchor', 'props', 'hydrate', 'intro', 'context']
 
 const render = (
   Component,


### PR DESCRIPTION
Fixes #118
Fixes #136

## Description

Support passing the svelte component context in `componentOptions`.

[Previously one had to write a wrapper component that could set the context](https://svelte-recipes.netlify.app/testing/#testing-the-context-api).

## Usage

```svelte
<!-- Test.svelte -->
<script lang="ts">
  import { getContext } from "svelte";

  const foo = getContext("foo");

  console.log({ foo });
</script>

{foo}
```

```ts
// Test.test.ts
import { render } from "@testing-library/svelte";
import Test from "./Test.svelte";

it("gets context", () => {
  render(Test, { context: new Map([["foo", "bar"]]) });
});
```