### PR TITLE
fix: update incorrect Node version requirement from 8 to 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/testing-library/svelte-testing-library/issues"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "keywords": [
     "testing",


### PR DESCRIPTION
Also tests on Node 14 and 16. IMO this isn't a breaking change, since Node 8 was already broken because of our DOM Testing Library version using newer syntax.