### PR TITLE
feat: add context to the allowed options

### DIFF
--- a/src/__tests__/__snapshots__/auto-cleanup-skip.test.js.snap
+++ b/src/__tests__/__snapshots__/auto-cleanup-skip.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`auto-cleanup-skip second 1`] = `"<div><h1 data-testid=\\"test\\">Hello world!</h1> <button>Button</button></div>"`;
+exports[`auto-cleanup-skip second 1`] = `"<div><h1 data-testid=\\"test\\">Hello world!</h1> <div>we have undefined</div> <button>Button</button></div>"`;

--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -11,6 +11,10 @@ exports[`render should accept svelte component options 1`] = `
       !
     </h1>
      
+    <div>
+      we have context
+    </div>
+     
     <button>
       Button
     </button>

--- a/src/__tests__/fixtures/Comp.svelte
+++ b/src/__tests__/fixtures/Comp.svelte
@@ -1,7 +1,11 @@
 <script>
+  import { getContext } from 'svelte'
+
   export let name
 
   let buttonText = 'Button'
+
+  const contextName = getContext('name')
 
   function handleClick () {
     buttonText = 'Button Clicked'
@@ -11,5 +15,7 @@
 <style></style>
 
 <h1 data-testid="test">Hello {name}!</h1>
+
+<div>we have {contextName}</div>
 
 <button on:click={handleClick}>{buttonText}</button>

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -53,7 +53,8 @@ describe('render', () => {
     const { container } = stlRender(Comp, {
       target,
       anchor: div,
-      props: { name: 'World' }
+      props: { name: 'World' },
+      context: new Map([['name', 'context']])
     })
     expect(container).toMatchSnapshot()
   })
@@ -74,5 +75,16 @@ describe('render', () => {
     const { getByText } = render(CompDefault, { props: { name: 'World' } })
 
     expect(getByText('Hello World!')).toBeInTheDocument()
+  })
+
+  test("accept the 'context' option", () => {
+    const { getByText } = stlRender(Comp, {
+      props: {
+        name: 'Universe'
+      },
+      context: new Map([['name', 'context']])
+    })
+
+    expect(getByText('we have context')).toBeInTheDocument()
   })
 })

--- a/src/pure.js
+++ b/src/pure.js
@@ -4,7 +4,13 @@ import { tick } from 'svelte'
 const containerCache = new Map()
 const componentCache = new Set()
 
-const svleteComponentOptions = ['anchor', 'props', 'hydrate', 'intro']
+const svelteComponentOptions = [
+  'anchor',
+  'props',
+  'hydrate',
+  'intro',
+  'context'
+]
 
 const render = (
   Component,
@@ -17,19 +23,21 @@ const render = (
   const ComponentConstructor = Component.default || Component
 
   const checkProps = (options) => {
-    const isProps = !Object.keys(options).some(option => svleteComponentOptions.includes(option))
+    const isProps = !Object.keys(options).some((option) =>
+      svelteComponentOptions.includes(option)
+    )
 
     // Check if any props and Svelte options were accidentally mixed.
     if (!isProps) {
-      const unrecognizedOptions = Object
-        .keys(options)
-        .filter(option => !svleteComponentOptions.includes(option))
+      const unrecognizedOptions = Object.keys(options).filter(
+        (option) => !svelteComponentOptions.includes(option)
+      )
 
       if (unrecognizedOptions.length > 0) {
         throw Error(`
-          Unknown options were found [${unrecognizedOptions}]. This might happen if you've mixed 
-          passing in props with Svelte options into the render function. Valid Svelte options 
-          are [${svleteComponentOptions}]. You can either change the prop names, or pass in your 
+          Unknown options were found [${unrecognizedOptions}]. This might happen if you've mixed
+          passing in props with Svelte options into the render function. Valid Svelte options
+          are [${svelteComponentOptions}]. You can either change the prop names, or pass in your
           props for that component via the \`props\` option.\n\n
           Eg: const { /** Results **/ } = render(MyComponent, { props: { /** props here **/ } })\n\n
         `)
@@ -76,7 +84,7 @@ const render = (
   }
 }
 
-const cleanupAtContainer = container => {
+const cleanupAtContainer = (container) => {
   const { target, component } = containerCache.get(container)
 
   if (componentCache.has(component)) component.$destroy()


### PR DESCRIPTION
For #136

Allows 'context' as one of the Svelte options.

Note that most of the changes are due to prettier and husky. (I pushed a new version with husky disabled, because the signal to noise ratio was just too bad. If the PR makes sense we can always prettierify it after the fact)