### PR TITLE
fix: missing Constructor constraint to first render() type signature

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,7 @@ export interface RenderOptions<Q extends Queries = typeof queries> {
 }
 
 export function render<C extends SvelteComponent>(
-  component: C,
+  component: Constructor<C>,
   componentOptions?: SvelteComponentOptions<C>,
   renderOptions?: Omit<RenderOptions, 'queries'>
 ): RenderResult<C>


### PR DESCRIPTION
Fixing the previous merged proposal: https://github.com/testing-library/svelte-testing-library/pull/202. `Constructor<T>` constraint was applied only to one of the two signatures of the `render()` function.