### PR TITLE
chore: Add Svelte 4 as supported version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "contributors:generate": "all-contributors generate"
   },
   "peerDependencies": {
-    "svelte": "3.x"
+    "svelte": "^3 || ^4"
   },
   "dependencies": {
     "@testing-library/dom": "^8.1.0"


### PR DESCRIPTION
closes https://github.com/testing-library/svelte-testing-library/issues/223