### PR TITLE
fix: added module path for `types` to the `exports` map

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "@testing-library/svelte",
   "version": "0.0.0-semantically-released",
   "description": "Simple and complete Svelte testing utilities that encourage good testing practices.",
-  "exports": "src/index.js",
+  "exports": {
+    ".": {
+      "default": "./src/index.js",
+      "types": "./types/index.d.ts"
+    }
+  },
   "type": "module",
   "types": "types/index.d.ts",
   "license": "MIT",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Rahim Alwer <https://github.com/mihar-22>
 
 import {queries, Queries, BoundFunction, EventType} from '@testing-library/dom'
-import { SvelteComponent, ComponentProps } from 'svelte/types/runtime'
+import { SvelteComponent, ComponentProps } from 'svelte'
 
 export * from '@testing-library/dom'
 


### PR DESCRIPTION
The `exports` map in `package.json` was missing it's `types` module path, causing the import of `@testing-library/svelte` to throw a type error whenever users had `"moduleResolution": "nodenext"` set in their `tsconfig.json`.