### PR TITLE
fix: Update package.json exports order

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Simple and complete Svelte testing utilities that encourage good testing practices.",
   "exports": {
     ".": {
-      "default": "./src/index.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
     }
   },
   "type": "module",


### PR DESCRIPTION
Hi there, I'm having issues with type resolution after updating from 3.2.2 to 4.0.2. I ran it through publint, which states the `exports` field needs to list `types` before everything else: https://publint.dev/@testing-library/svelte@4.0.2