### PR TITLE
fix(types): correct type annotation for `act`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,7 +60,8 @@ export type FireObject = {
 export const fireEvent: FireFunction & FireObject;
 
 /**
- * Calls a function or resolves a Promise and notifies Svelte to immediately flushes any pending
- * state changes.
+ * Calls a function and notifies Svelte to flush any pending state changes.
+ *
+ * If the function returns a Promise, that Promise will be resolved first.
  */
-export function act(fn?: Function | Promise<any>): Promise<void>
+export function act(fn?: () => unknown): Promise<void>


### PR DESCRIPTION
The implementation of `act()` requires a function, but the type annotation says it takes either a function or a Promise.

After checking out the history, I found this mismatch was created by #54, which added both the type annotation and implementation for `act`. This leads me to think the best path forward now is to simply adjust the type annotation to match reality, rather than updating the implementation to support a Promise.

Closes #134