### PR TITLE
chore: fix linting, formatting, and git hooks configs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,19 +3,36 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    'vitest-globals/env': true
+    'vitest-globals/env': true,
   },
-  extends: ['standard', 'plugin:vitest-globals/recommended'],
+  extends: [
+    'standard',
+    'plugin:vitest-globals/recommended',
+    'plugin:svelte/recommended',
+    'prettier',
+  ],
   plugins: ['svelte', 'simple-import-sort'],
   rules: {
-    'max-len': ['warn', { code: 100 }],
     'simple-import-sort/imports': 'error',
-    'no-multiple-empty-lines': ['error', { max: 2, maxBOF: 2, maxEOF: 0 }],
   },
   overrides: [
+    {
+      files: ['*.ts'],
+      parser: '@typescript-eslint/parser',
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/stylistic',
+        'prettier',
+      ],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+        'import/export': 'off',
+      },
+    },
   ],
   parserOptions: {
     ecmaVersion: 2022,
     sourceType: 'module',
   },
+  ignorePatterns: ['!.*'],
 }

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,5 +34,5 @@ module.exports = {
     ecmaVersion: 2022,
     sourceType: 'module',
   },
-  ignorePatterns: ['!.*'],
+  ignorePatterns: ['!/.*'],
 }

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,10 @@ module.exports = {
         'prettier',
       ],
       rules: {
+        '@typescript-eslint/ban-types': [
+          'error',
+          { types: { '{}': false }, extendDefaults: true },
+        ],
         '@typescript-eslint/no-explicit-any': 'off',
         'import/export': 'off',
       },

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no-install lint-staged

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,9 @@
 semi: false
 singleQuote: true
+trailingComma: es5
+plugins:
+  - prettier-plugin-svelte
+overrides:
+  - files: "*.svelte"
+    options:
+      parser: svelte

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
       "git add README.md .all-contributorsrc"
     ],
     "src/**/*": [
-      "npx --no-install vitest run"
+      "npx --no-install vitest related --run"
     ],
     "*.{js,cjs,ts,svelte,json,yml,yaml}": [
       "npx --no-install prettier --check"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   ],
   "scripts": {
     "toc": "doctoc README.md",
-    "lint": "eslint src --fix",
+    "lint": "(prettier . --check || true) && eslint .",
+    "format": "prettier . --write && eslint . --fix",
     "test": "vitest run src",
     "test:watch": "npm run test -- --watch",
     "test:update": "npm run test -- --updateSnapshot --coverage",
@@ -61,10 +62,13 @@
     "@commitlint/config-conventional": "^17.6.6",
     "@sveltejs/vite-plugin-svelte": "^2.4.2",
     "@testing-library/jest-dom": "^5.16.5",
+    "@typescript-eslint/eslint-plugin": "^6.19.1",
+    "@typescript-eslint/parser": "^6.19.1",
     "@vitest/coverage-c8": "^0.33.0",
     "all-contributors-cli": "^6.26.0",
     "doctoc": "^2.2.1",
     "eslint": "^8.43.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^16.0.1",
@@ -77,30 +81,28 @@
     "lint-staged": "^13.2.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
+    "prettier-plugin-svelte": "^3.1.2",
     "svelte": "^4.0.1",
+    "svelte-jester": "^3.0.0",
+    "typescript": "^5.3.3",
     "vite": "^4.3.9",
     "vitest": "^0.33.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
   "lint-staged": {
-    "README.md": [
+    "{README.md,.all-contributorsrc}": [
       "npm run toc",
-      "prettier --parser markdown --write",
-      "git add"
-    ],
-    ".all-contributorsrc": [
       "npm run contributors:generate",
-      "git add"
+      "npx --no-install prettier --write README.md .all-contributorsrc",
+      "git add README.md .all-contributorsrc"
     ],
-    "**/*.js": [
-      "npm run lint",
-      "npm test",
-      "git add"
+    "src/**/*": [
+      "npx --no-install vitest run"
+    ],
+    "*.{js,cjs,ts,svelte,json,yml,yaml}": [
+      "npx --no-install prettier --check"
+    ],
+    "*.{js,cjs,ts,svelte}": [
+      "npx --no-install eslint"
     ]
   },
   "commitlint": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,7 @@ export function cleanup(): void
 export type FireFunction = (element: Document | Element | Window, event: Event) => Promise<boolean>;
 
 export type FireObject = {
-  [K in EventType]: (element: Document | Element | Window, options?: Record<string, unknown>) => Promise<boolean>;
+  [K in EventType]: (element: Document | Element | Window, options?: {}) => Promise<boolean>;
 };
 
 export const fireEvent: FireFunction & FireObject;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,9 +2,8 @@
 // Project: https://github.com/testing-library/svelte-testing-library
 // Definitions by: Rahim Alwer <https://github.com/mihar-22>
 
-import {queries, Queries, BoundFunction, EventType} from '@testing-library/dom'
-
-import { SvelteComponent, ComponentProps, ComponentConstructorOptions  } from 'svelte'
+import {BoundFunction, EventType,Queries, queries} from '@testing-library/dom'
+import { ComponentConstructorOptions,ComponentProps, SvelteComponent  } from 'svelte'
 
 export * from '@testing-library/dom'
 
@@ -54,7 +53,7 @@ export function cleanup(): void
 export type FireFunction = (element: Document | Element | Window, event: Event) => Promise<boolean>;
 
 export type FireObject = {
-  [K in EventType]: (element: Document | Element | Window, options?: {}) => Promise<boolean>;
+  [K in EventType]: (element: Document | Element | Window, options?: Record<string, uknown>) => Promise<boolean>;
 };
 
 export const fireEvent: FireFunction & FireObject;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,7 @@ export function cleanup(): void
 export type FireFunction = (element: Document | Element | Window, event: Event) => Promise<boolean>;
 
 export type FireObject = {
-  [K in EventType]: (element: Document | Element | Window, options?: Record<string, uknown>) => Promise<boolean>;
+  [K in EventType]: (element: Document | Element | Window, options?: Record<string, unknown>) => Promise<boolean>;
 };
 
 export const fireEvent: FireFunction & FireObject;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Overview

This PR fixes some code quality configs and hookups that we making it difficult to contribute effectively to this project.

Part of a two PR change set:

1. #291 **<-- you are here**
2. #292

## Change log

- Incorporate `eslint-plugin-svelte`, `@typescript-eslint/eslint-plugin`, `eslint-plugin-prettier` into the ESLint config to:
    - Lint `.svelte` files
    - Lint `.d.ts` files
    - Avoid conflicts with prettier
- Migrate the Husky config [to v8](https://typicode.github.io/husky/migrating-from-v4.html)
- Fix up the `lint-staged` config now that Husky is actually working

(On a personal note, I'm not a huge fan of pre-commit hooks anymore. I find they interfere with people's personal work styles, and they're pretty unnecessary in a PR-squashing-based workflow. **I'd be down to ditch the pre-commit stuff from the repo entirely**)