### PR TITLE
ci: test against svelte v3 and v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,29 +14,31 @@ jobs:
   main:
     # ignore all-contributors PRs
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
+    name: Node ${{ matrix.node }}, Svelte ${{ matrix.svelte }}
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: ['16', '18', '20']
+        svelte: ['3', '4']
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+        run: |
+          npm install --no-package-lock
+          npm install --no-save svelte@${{ matrix.svelte }}
 
       - name: ▶️ Run validate script
         run: npm run validate
 
       - name: ⬆️ Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 
   release:
     needs: main
@@ -46,17 +48,15 @@ jobs:
       github.ref) && github.event_name == 'push' }}
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+        run: npm install --no-package-lock
 
       - name: 🚀 Release
         uses: cycjimmy/semantic-release-action@v2

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
     "prettier-plugin-svelte": "^3.1.2",
-    "svelte": "^4.0.1",
+    "svelte": "^3 || ^4",
     "svelte-jester": "^3.0.0",
     "typescript": "^5.3.3",
     "vite": "^4.3.9",


### PR DESCRIPTION
## Overview

This is the second PR in a series to add multiple Svelte versions and test runners to our CI test matrix.

1. #294 
2. #295 **<-- you are here**
3. #297
4. TODO add Jest to CI matrix

## Change log

This PR updates the CI test matrix to install different Svelte versions prior to testing

- Replace third party action with `npm install` for flexibility and security
- Call `npm install svelte` with a specific version in CI from the matrix
- Update action dependencies to remove CI warnings
    - `cycjimmy/semantic-release-action` needs an update too, but I'd like to leave release stuff to its own PR in case of issues