### PR TITLE
chore: remove husky, lint-staged, and commitlint

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,1 +1,0 @@
-enabled: false

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
     "@testing-library/dom": "^9.3.1"
   },
   "devDependencies": {
-    "@commitlint/cli": "^17.6.6",
-    "@commitlint/config-conventional": "^17.6.6",
     "@sveltejs/vite-plugin-svelte": "^2.4.2",
     "@testing-library/jest-dom": "^6.3.0",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
@@ -79,9 +77,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-svelte": "^2.32.0",
     "eslint-plugin-vitest-globals": "^1.3.1",
-    "husky": "^8.0.3",
     "jsdom": "^22.1.0",
-    "lint-staged": "^13.2.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
     "prettier-plugin-svelte": "^3.1.2",
@@ -90,27 +86,5 @@
     "typescript": "^5.3.3",
     "vite": "^4.3.9",
     "vitest": "^0.33.0"
-  },
-  "lint-staged": {
-    "{README.md,.all-contributorsrc}": [
-      "npm run toc",
-      "npm run contributors:generate",
-      "npx --no-install prettier --write README.md .all-contributorsrc",
-      "git add README.md .all-contributorsrc"
-    ],
-    "src/**/*": [
-      "npx --no-install vitest related --run"
-    ],
-    "*.{js,cjs,ts,svelte,json,yml,yaml}": [
-      "npx --no-install prettier --check"
-    ],
-    "*.{js,cjs,ts,svelte}": [
-      "npx --no-install eslint"
-    ]
-  },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
   }
 }


### PR DESCRIPTION
Husky, lint-staged, and commitlint all add heavy-handed constraints to local development that don't make a lot of sense in a world where:

- CI is fast because this project is small and will remain small
- Pull-requests are squash merged
- Pull-request titles are checked via CI

Relates to #299, which adds contributing documentation.

Closes #293. 