### PR TITLE
ci: update semantic-pull-request and cleanup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,8 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: husky
-    versions:
-    - 5.0.9
-    - 5.1.0
-    - 5.1.1
-    - 5.1.2
-    - 5.1.3
-    - 5.2.0
-  - dependency-name: "@commitlint/config-conventional"
-    versions:
-    - 12.0.0
-    - 12.0.1
-  - dependency-name: "@commitlint/cli"
-    versions:
-    - 12.0.0
-    - 12.0.1
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '10:00'
+    open-pull-requests-limit: 10

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: 'Lint PR'
 
 on:
   pull_request_target:
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Very minor updates and cleanup to address deprecation warnings currently happening in CI. Had this lying around locally, mostly just want to get it out of my queue