### PR TITLE
fix: remove DOM elements even if component creation fails

### DIFF
--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -18,7 +18,6 @@ exports[`render > should accept svelte component options 1`] = `
     <button>
       Button
     </button>
-    <!--&lt;Comp&gt;-->
     <div />
   </div>
 </body>

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { cleanup, render } from '..'
+import Mounter from './fixtures/Mounter.svelte'
+
+const onMounted = vi.fn()
+const onDestroyed = vi.fn()
+const renderSubject = () => render(Mounter, { onMounted, onDestroyed })
+
+describe('cleanup', () => {
+  test('cleanup unmounts component and deletes element', () => {
+    renderSubject()
+
+    cleanup()
+
+    expect(onDestroyed).toHaveBeenCalledOnce()
+    expect(document.body).toBeEmptyDOMElement()
+  })
+
+  test('cleanup handles unexpected errors during mount', () => {
+    onMounted.mockImplementation(() => {
+      throw new Error('oh no!')
+    })
+
+    expect(renderSubject).toThrowError()
+    cleanup()
+
+    expect(document.body).toBeEmptyDOMElement()
+  })
+})

--- a/src/__tests__/fixtures/Mounter.svelte
+++ b/src/__tests__/fixtures/Mounter.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onDestroy,onMount } from 'svelte'
+  import { onDestroy, onMount } from 'svelte'
 
   export let onMounted
   export let onDestroyed

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  plugins: [svelte()],
+  plugins: [svelte({ hot: false })],
   resolve: {
     // Ensure `browser` exports are used in tests
     // Vitest prefers modules' `node` export by default


### PR DESCRIPTION
## Overview

This PR fixes #190 by simplifying the caching strategy and ensuring the `target` div is added to the cache as soon as it's created, rather than after the component is rendered.

While working on this PR, I noticed a few inconsistencies with the `render` function's API, so I filed #312 and #313

Will keep this as a draft until I've smoke tested on my current app's suite

## Change log

- Add `target` element to cache immediately
- Consolidate component creation and caching into `renderComponent` function
- Consolidate component destruction and target removal into `cleanupComponent` and `cleanupTarget` functions
- ~Remove `component.$$.on_destroy` usage~ I elected to keep this for strict backwards compatibility
    - `$$.on_destroy` was added in #54, which was a big rewrite about 5 years ago
    - Unfortunately I can't find any historical information about its intent. Perhaps @benmonro remembers?
    - It will not be possible in Svelte 5 as far as I can tell, and I think that's fine, because it's completely unnecessary if the user sticks to `unmount` and `cleanup`