### PR TITLE
ci: run release workflow on `next` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Had a spare moment and this seemed helpful. Don't have any personal preferences on the branch name, but `next` felt easy because it was already configured and matches Svelte itself, which is currently publishing v5 on its `next` dist-tag in npm