### PR TITLE
feat: add Svelte v5-next support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,23 @@ jobs:
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     name: Node ${{ matrix.node }}, Svelte ${{ matrix.svelte }}, ${{ matrix.test-runner }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         node: ['16', '18', '20']
         svelte: ['3', '4']
         test-runner: ['vitest:jsdom', 'vitest:happy-dom']
+        experimental: [false]
+        include:
+          - node: '20'
+            svelte: 'next'
+            test-runner: 'vitest:jsdom'
+            experimental: true
+          - node: '20'
+            svelte: 'next'
+            test-runner: 'vitest:happy-dom'
+            experimental: true
 
     steps:
       - name: ⬇️ Checkout repo

--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
     "contributors:generate": "all-contributors generate"
   },
   "peerDependencies": {
-    "svelte": "^3 || ^4"
+    "svelte": "^3 || ^4 || ^5"
   },
   "dependencies": {
     "@testing-library/dom": "^9.3.1"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.4.2",
+    "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@typescript-eslint/eslint-plugin": "6.19.1",
@@ -94,11 +94,11 @@
     "npm-run-all": "^4.1.5",
     "prettier": "3.2.4",
     "prettier-plugin-svelte": "3.1.2",
-    "svelte": "^3 || ^4",
+    "svelte": "^4.2.10",
     "svelte-check": "^3.6.3",
     "svelte-jester": "^3.0.0",
     "typescript": "^5.3.3",
-    "vite": "^4.3.9",
+    "vite": "^5.1.1",
     "vitest": "^0.33.0"
   }
 }

--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`render > should accept svelte component options 1`] = `
+exports[`render > should accept svelte v4 component options 1`] = `
 <body>
   <div>
     <h1
@@ -20,5 +20,29 @@ exports[`render > should accept svelte component options 1`] = `
     </button>
     <div />
   </div>
+</body>
+`;
+
+exports[`render > should accept svelte v5 component options 1`] = `
+<body>
+  
+  
+  
+  <section>
+    <h1
+      data-testid="test"
+    >
+      Hello World!
+    </h1>
+     
+    <div>
+      we have context
+    </div>
+     
+    <button>
+      Button
+    </button>
+    
+  </section>
 </body>
 `;

--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -18,7 +18,6 @@ exports[`render > should accept svelte component options 1`] = `
     <button>
       Button
     </button>
-    <!--&lt;Comp&gt;-->
     <div />
   </div>
 </body>

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { cleanup, render } from '..'
+import Mounter from './fixtures/Mounter.svelte'
+
+const onMounted = vi.fn()
+const onDestroyed = vi.fn()
+const renderSubject = () => render(Mounter, { onMounted, onDestroyed })
+
+describe('cleanup', () => {
+  test('cleanup unmounts component and deletes element', () => {
+    renderSubject()
+
+    cleanup()
+
+    expect(onDestroyed).toHaveBeenCalledOnce()
+    expect(document.body).toBeEmptyDOMElement()
+  })
+
+  test('cleanup handles unexpected errors during mount', () => {
+    onMounted.mockImplementation(() => {
+      throw new Error('oh no!')
+    })
+
+    expect(renderSubject).toThrowError()
+    cleanup()
+
+    expect(document.body).toBeEmptyDOMElement()
+  })
+})

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -1,24 +1,29 @@
 import { describe, expect, test, vi } from 'vitest'
 
-import { cleanup, render } from '..'
+import { act, cleanup, render } from '..'
 import Mounter from './fixtures/Mounter.svelte'
 
-const onMounted = vi.fn()
+const onExecuted = vi.fn()
 const onDestroyed = vi.fn()
-const renderSubject = () => render(Mounter, { onMounted, onDestroyed })
+const renderSubject = () => render(Mounter, { onExecuted, onDestroyed })
 
 describe('cleanup', () => {
-  test('cleanup unmounts component and deletes element', () => {
+  test('cleanup deletes element', async () => {
     renderSubject()
-
     cleanup()
 
-    expect(onDestroyed).toHaveBeenCalledOnce()
     expect(document.body).toBeEmptyDOMElement()
   })
 
+  test('cleanup unmounts component', async () => {
+    await act(renderSubject)
+    cleanup()
+
+    expect(onDestroyed).toHaveBeenCalledOnce()
+  })
+
   test('cleanup handles unexpected errors during mount', () => {
-    onMounted.mockImplementation(() => {
+    onExecuted.mockImplementation(() => {
       throw new Error('oh no!')
     })
 

--- a/src/__tests__/fixtures/Mounter.svelte
+++ b/src/__tests__/fixtures/Mounter.svelte
@@ -1,11 +1,19 @@
 <script>
   import { onDestroy, onMount } from 'svelte'
 
-  export let onMounted
-  export let onDestroyed
+  export let onExecuted = undefined
+  export let onMounted = undefined
+  export let onDestroyed = undefined
 
-  onMount(() => onMounted())
-  onDestroy(() => onDestroyed())
+  onExecuted?.()
+
+  onMount(() => {
+    onMounted?.()
+  })
+
+  onDestroy(() => {
+    onDestroyed?.()
+  })
 </script>
 
 <button />

--- a/src/__tests__/fixtures/Mounter.svelte
+++ b/src/__tests__/fixtures/Mounter.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onDestroy,onMount } from 'svelte'
+  import { onDestroy, onMount } from 'svelte'
 
   export let onMounted
   export let onDestroyed

--- a/src/__tests__/fixtures/Rerender.svelte
+++ b/src/__tests__/fixtures/Rerender.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { onDestroy, onMount } from 'svelte'
+
+  export let onExecuted = undefined
+  export let onMounted = undefined
+  export let onDestroyed = undefined
+
+  export let name = ''
+
+  onExecuted?.()
+
+  onMount(() => onMounted?.())
+
+  onDestroy(() => onDestroyed?.())
+</script>
+
+<div data-testid="test">Hello {name}!</div>

--- a/src/__tests__/mount.test.js
+++ b/src/__tests__/mount.test.js
@@ -3,31 +3,31 @@ import { describe, expect, test, vi } from 'vitest'
 import { act, render, screen } from '..'
 import Mounter from './fixtures/Mounter.svelte'
 
-describe('mount and destroy', () => {
-  const handleMount = vi.fn()
-  const handleDestroy = vi.fn()
+const onMounted = vi.fn()
+const onDestroyed = vi.fn()
+const renderSubject = () => render(Mounter, { onMounted, onDestroyed })
 
+describe('mount and destroy', () => {
   test('component is mounted', async () => {
-    await act(() => {
-      render(Mounter, { onMounted: handleMount, onDestroyed: handleDestroy })
-    })
+    renderSubject()
 
     const content = screen.getByRole('button')
 
-    expect(handleMount).toHaveBeenCalledOnce()
     expect(content).toBeInTheDocument()
+    await act()
+    expect(onMounted).toHaveBeenCalledOnce()
   })
 
   test('component is destroyed', async () => {
-    const { unmount } = render(Mounter, {
-      onMounted: handleMount,
-      onDestroyed: handleDestroy,
-    })
+    const { unmount } = renderSubject()
 
-    await act(() => unmount())
+    await act()
+    unmount()
+
     const content = screen.queryByRole('button')
 
-    expect(handleDestroy).toHaveBeenCalledOnce()
     expect(content).not.toBeInTheDocument()
+    await act()
+    expect(onDestroyed).toHaveBeenCalledOnce()
   })
 })

--- a/src/__tests__/rerender.test.js
+++ b/src/__tests__/rerender.test.js
@@ -1,10 +1,8 @@
-/**
- * @jest-environment jsdom
- */
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
-import { render } from '..'
+import { act, render } from '..'
 import Comp from './fixtures/Comp.svelte'
+import Mounter from './fixtures/Mounter.svelte'
 
 describe('rerender', () => {
   test('mounts new component successfully', () => {
@@ -15,16 +13,13 @@ describe('rerender', () => {
     expect(container.firstChild).toHaveTextContent('Hello World 2!')
   })
 
-  test('destroys old component', () => {
-    let isDestroyed
+  test('destroys old component', async () => {
+    const onDestroyed = vi.fn()
+    const { rerender } = render(Mounter, { onDestroyed })
 
-    const { rerender, component } = render(Comp, { props: { name: '' } })
-
-    component.$$.on_destroy.push(() => {
-      isDestroyed = true
-    })
-    rerender({ props: { name: '' } })
-    expect(isDestroyed).toBeTruthy()
+    await act()
+    await act(() => rerender({}))
+    expect(onDestroyed).toHaveBeenCalledOnce()
   })
 
   test('destroys old components on multiple rerenders', () => {

--- a/src/__tests__/transition.test.js
+++ b/src/__tests__/transition.test.js
@@ -1,10 +1,11 @@
 import { userEvent } from '@testing-library/user-event'
+import { VERSION as SVELTE_VERSION } from 'svelte/compiler'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { render, screen, waitFor } from '..'
 import Transitioner from './fixtures/Transitioner.svelte'
 
-describe('transitions', () => {
+describe.runIf(SVELTE_VERSION < '5')('transitions', () => {
   beforeEach(() => {
     if (window.navigator.userAgent.includes('jsdom')) {
       const raf = (fn) => setTimeout(() => fn(new Date()), 16)

--- a/src/pure.js
+++ b/src/pure.js
@@ -77,9 +77,15 @@ const render = (
     container,
     component,
     debug: (el = container) => console.log(prettyDOM(el)),
-    rerender: (options) => {
-      cleanupComponent(component)
-      component = renderComponent(options)
+    rerender: async (props) => {
+      if (props.props) {
+        console.warn(
+          'rerender({ props: {...} }) deprecated, use rerender({...}) instead'
+        )
+        props = props.props
+      }
+      component.$set(props)
+      await Svelte.tick()
     },
     unmount: () => {
       cleanupComponent(component)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,25 +2,42 @@
 // Project: https://github.com/testing-library/svelte-testing-library
 // Definitions by: Rahim Alwer <https://github.com/mihar-22>
 
-import {BoundFunction, EventType,Queries, queries} from '@testing-library/dom'
-import { ComponentConstructorOptions,ComponentProps, SvelteComponent  } from 'svelte'
+import {
+  BoundFunction,
+  EventType,
+  Queries,
+  queries,
+} from '@testing-library/dom'
+import {
+  ComponentConstructorOptions,
+  ComponentProps,
+  SvelteComponent,
+} from 'svelte'
 
 export * from '@testing-library/dom'
 
-type SvelteComponentOptions<C extends SvelteComponent> = ComponentProps<C> | Pick<ComponentConstructorOptions<ComponentProps<C>>, "anchor" | "props" | "hydrate" | "intro" | "context">
+type SvelteComponentOptions<C extends SvelteComponent> =
+  | ComponentProps<C>
+  | Pick<
+      ComponentConstructorOptions<ComponentProps<C>>,
+      'anchor' | 'props' | 'hydrate' | 'intro' | 'context'
+    >
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
-type Constructor<T> = new (...args: any[]) => T;
+type Constructor<T> = new (...args: any[]) => T
 
 /**
  * Render a Component into the Document.
  */
-export type RenderResult<C extends SvelteComponent, Q extends Queries = typeof queries> = {
+export type RenderResult<
+  C extends SvelteComponent,
+  Q extends Queries = typeof queries,
+> = {
   container: HTMLElement
   component: C
   debug: (el?: HTMLElement | DocumentFragment) => void
-  rerender: (options: SvelteComponentOptions<C>) => void
+  rerender: (props: ComponentProps<C>) => Promise<void>
   unmount: () => void
 } & { [P in keyof Q]: BoundFunction<Q[P]> }
 
@@ -38,7 +55,7 @@ export function render<C extends SvelteComponent>(
 export function render<C extends SvelteComponent, Q extends Queries>(
   component: Constructor<C>,
   componentOptions?: SvelteComponentOptions<C>,
-  renderOptions?: RenderOptions<Q>,
+  renderOptions?: RenderOptions<Q>
 ): RenderResult<C, Q>
 
 /**
@@ -50,13 +67,19 @@ export function cleanup(): void
  * Fires DOM events on an element provided by @testing-library/dom. Since Svelte needs to flush
  * pending state changes via `tick`, these methods have been override and now return a promise.
  */
-export type FireFunction = (element: Document | Element | Window, event: Event) => Promise<boolean>;
+export type FireFunction = (
+  element: Document | Element | Window,
+  event: Event
+) => Promise<boolean>
 
 export type FireObject = {
-  [K in EventType]: (element: Document | Element | Window, options?: {}) => Promise<boolean>;
-};
+  [K in EventType]: (
+    element: Document | Element | Window,
+    options?: {}
+  ) => Promise<boolean>
+}
 
-export const fireEvent: FireFunction & FireObject;
+export const fireEvent: FireFunction & FireObject
 
 /**
  * Calls a function and notifies Svelte to flush any pending state changes.

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  plugins: [svelte()],
+  plugins: [svelte({ hot: false })],
   resolve: {
     // Ensure `browser` exports are used in tests
     // Vitest prefers modules' `node` export by default


### PR DESCRIPTION
## Overview

This PR is an alternative approach to #284 (CC @yanick) that adds experimental support for `svelte@next` without breaking support for Svelte v3 nor v4. I think adding support for the prerelease version of Svelte v5  as soon as possible will be a really helpful move for everyone trying to migrate - myself very much included.

This PR requires the cleanup work I did in #314. Please see https://github.com/mcous/svelte-testing-library/pull/1 in my fork for the incremental diff from #314 to here. This PR is ready for review, but #314 should merge first

## Issues encountered

- `onMount` and `onDestroy` are attached and called asynchronously
    - If you synchronously create and then destroy a component, neither `onMount` nor `onDestroy` will be called
    - Tests required a sprinkling of `act()`s to get passing again
- `anchor` option has been removed
    - Doesn't directly affect this library, we just have a test that exercises it
- `Element.animate` is required to run transitions
    - Doesn't directly affect this library
    - _Does_ affect any users running transitions in tests, including our own test suite
    - Not sure what the right move is here; probably a documentation update
- `happy-dom` is pretty broken, _probably_ a Svelte issue
    - See #319 
    - See sveltejs/svelte#10358

## Work after this PR

- If we want to guarantee that `onMount` and `onDestroy` are called, we'll need to make `render` async so it can call `tick()` after render, which will be a breaking change
- Accordingly, I think we'll still want to issue a major bump that drops Svelte 3 and Node 16, maybe when Svelte 5 proper is released
- We can and should keep Svelte 4 support, in my opinion
