### PR TITLE
test: remove unnecessary tests and skips

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,6 +23,9 @@ module.exports = {
       parserOptions: {
         parser: '@typescript-eslint/parser',
       },
+      rules: {
+        'no-undef-init': 'off',
+      },
     },
     {
       files: ['*.ts'],

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 scripts/*
 .eslintignore
 .prettierignore
+.all-contributorsrc

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -4,6 +4,6 @@ trailingComma: es5
 plugins:
   - prettier-plugin-svelte
 overrides:
-  - files: "*.svelte"
+  - files: '*.svelte'
     options:
       parser: svelte

--- a/src/__tests__/act.test.js
+++ b/src/__tests__/act.test.js
@@ -1,25 +1,13 @@
-import { beforeEach, describe, expect, test } from 'vitest'
+import { setTimeout } from 'node:timers/promises'
 
-import { act, fireEvent, render as stlRender } from '@testing-library/svelte'
+import { act, render } from '@testing-library/svelte'
+import { describe, expect, test } from 'vitest'
+
 import Comp from './fixtures/Comp.svelte'
 
 describe('act', () => {
-  let props
-
-  const render = () => {
-    return stlRender(Comp, {
-      props
-    })
-  }
-
-  beforeEach(() => {
-    props = {
-      name: 'World'
-    }
-  })
-
   test('state updates are flushed', async () => {
-    const { getByText } = render()
+    const { getByText } = render(Comp)
     const button = getByText('Button')
 
     expect(button).toHaveTextContent('Button')
@@ -31,24 +19,13 @@ describe('act', () => {
     expect(button).toHaveTextContent('Button Clicked')
   })
 
-  test('findByTestId returns the element', async () => {
-    const { findByTestId } = render()
-
-    expect(await findByTestId('test')).toHaveTextContent(`Hello ${props.name}!`)
-  })
-
   test('accepts async functions', async () => {
-    const sleep = (ms) =>
-      new Promise((resolve) => {
-        setTimeout(() => resolve(), ms)
-      })
-
-    const { getByText } = render()
+    const { getByText } = render(Comp)
     const button = getByText('Button')
 
     await act(async () => {
-      await sleep(100)
-      await fireEvent.click(button)
+      await setTimeout(100)
+      button.click()
     })
 
     expect(button).toHaveTextContent('Button Clicked')

--- a/src/__tests__/auto-cleanup.test.js
+++ b/src/__tests__/auto-cleanup.test.js
@@ -1,6 +1,6 @@
+import { render } from '@testing-library/svelte'
 import { describe, expect, test } from 'vitest'
 
-import { render } from '@testing-library/svelte'
 import Comp from './fixtures/Comp.svelte'
 
 describe('auto-cleanup', () => {

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -1,7 +1,6 @@
+import { cleanup, render } from '@testing-library/svelte'
 import { describe, expect, test, vi } from 'vitest'
-import { VERSION as SVELTE_VERSION } from 'svelte/compiler'
 
-import { act, cleanup, render } from '@testing-library/svelte'
 import Mounter from './fixtures/Mounter.svelte'
 
 const onExecuted = vi.fn()
@@ -16,8 +15,8 @@ describe('cleanup', () => {
     expect(document.body).toBeEmptyDOMElement()
   })
 
-  test.runIf(SVELTE_VERSION < '5')('cleanup unmounts component', async () => {
-    await act(renderSubject)
+  test('cleanup unmounts component', () => {
+    renderSubject()
     cleanup()
 
     expect(onDestroyed).toHaveBeenCalledOnce()

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -1,6 +1,6 @@
+import { render } from '@testing-library/svelte'
 import { expect, test } from 'vitest'
 
-import { render } from '@testing-library/svelte'
 import Comp from './fixtures/Context.svelte'
 import { IS_HAPPYDOM, IS_SVELTE_5 } from './utils.js'
 

--- a/src/__tests__/debug.test.js
+++ b/src/__tests__/debug.test.js
@@ -1,19 +1,13 @@
 import { prettyDOM } from '@testing-library/dom'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-
 import { render } from '@testing-library/svelte'
+import { describe, expect, test, vi } from 'vitest'
+
 import Comp from './fixtures/Comp.svelte'
 
 describe('debug', () => {
-  beforeEach(() => {
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-  })
-
-  afterEach(() => {
-    console.log.mockRestore()
-  })
-
   test('pretty prints the base element', () => {
+    vi.stubGlobal('console', { log: vi.fn(), warn: vi.fn(), error: vi.fn() })
+
     const { baseElement, debug } = render(Comp, { props: { name: 'world' } })
 
     debug()

--- a/src/__tests__/events.test.js
+++ b/src/__tests__/events.test.js
@@ -1,6 +1,6 @@
+import { fireEvent, render } from '@testing-library/svelte'
 import { describe, expect, test } from 'vitest'
 
-import { fireEvent, render } from '@testing-library/svelte'
 import Comp from './fixtures/Comp.svelte'
 
 describe('events', () => {
@@ -21,7 +21,7 @@ describe('events', () => {
       button,
       new MouseEvent('click', {
         bubbles: true,
-        cancelable: true
+        cancelable: true,
       })
     )
 

--- a/src/__tests__/fixtures/Comp.svelte
+++ b/src/__tests__/fixtures/Comp.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script>
-  export let name
+  export let name = 'World'
 
   let buttonText = 'Button'
 

--- a/src/__tests__/fixtures/Context.svelte
+++ b/src/__tests__/fixtures/Context.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { getContext } from 'svelte';
+  import { getContext } from 'svelte'
 
-  const ctx = getContext('foo');
+  const ctx = getContext('foo')
 </script>
 
 <div>{ctx.message}</div>

--- a/src/__tests__/mount.test.js
+++ b/src/__tests__/mount.test.js
@@ -1,6 +1,6 @@
+import { act, render, screen } from '@testing-library/svelte'
 import { describe, expect, test, vi } from 'vitest'
 
-import { act, render, screen } from '@testing-library/svelte'
 import Mounter from './fixtures/Mounter.svelte'
 import { IS_HAPPYDOM, IS_SVELTE_5 } from './utils.js'
 

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/svelte'
-import { VERSION as SVELTE_VERSION } from 'svelte/compiler'
 import { describe, expect, test } from 'vitest'
 
 import Comp from './fixtures/Comp.svelte'
+import { IS_SVELTE_5 } from './utils.js'
 
 describe('render', () => {
   const props = { name: 'World' }
@@ -65,24 +65,21 @@ describe('render', () => {
     expect(baseElement.firstChild).toBe(container)
   })
 
-  test.runIf(SVELTE_VERSION < '5')(
-    'should accept anchor option in Svelte v4',
-    () => {
-      const baseElement = document.body
-      const target = document.createElement('section')
-      const anchor = document.createElement('div')
-      baseElement.appendChild(target)
-      target.appendChild(anchor)
+  test.skipIf(IS_SVELTE_5)('should accept anchor option in Svelte v4', () => {
+    const baseElement = document.body
+    const target = document.createElement('section')
+    const anchor = document.createElement('div')
+    baseElement.appendChild(target)
+    target.appendChild(anchor)
 
-      const { getByTestId } = render(
-        Comp,
-        { props, target, anchor },
-        { baseElement }
-      )
-      const firstElement = getByTestId('test')
+    const { getByTestId } = render(
+      Comp,
+      { props, target, anchor },
+      { baseElement }
+    )
+    const firstElement = getByTestId('test')
 
-      expect(target.firstChild).toBe(firstElement)
-      expect(target.lastChild).toBe(anchor)
-    }
-  )
+    expect(target.firstChild).toBe(firstElement)
+    expect(target.lastChild).toBe(anchor)
+  })
 })

--- a/src/__tests__/rerender.test.js
+++ b/src/__tests__/rerender.test.js
@@ -15,7 +15,7 @@ describe('rerender', () => {
   })
 
   test('warns if incorrect arguments shape used', async () => {
-    vi.stubGlobal('console', { warn: vi.fn() })
+    vi.stubGlobal('console', { log: vi.fn(), warn: vi.fn(), error: vi.fn() })
 
     const { rerender } = render(Comp, { name: 'World' })
     const element = screen.getByText('Hello World!')

--- a/src/__tests__/transition.test.js
+++ b/src/__tests__/transition.test.js
@@ -1,12 +1,11 @@
+import { render, screen, waitFor } from '@testing-library/svelte'
 import { userEvent } from '@testing-library/user-event'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import Transitioner from './fixtures/Transitioner.svelte'
 import { IS_JSDOM, IS_SVELTE_5 } from './utils.js'
 
-import { render, screen, waitFor } from '@testing-library/svelte'
-import Transitioner from './fixtures/Transitioner.svelte'
-
-describe.runIf(!IS_SVELTE_5)('transitions', () => {
+describe.skipIf(IS_SVELTE_5)('transitions', () => {
   beforeEach(() => {
     if (!IS_JSDOM) return
 

--- a/src/vitest.js
+++ b/src/vitest.js
@@ -1,6 +1,5 @@
-import { afterEach } from 'vitest'
-
 import { act, cleanup } from '@testing-library/svelte'
+import { afterEach } from 'vitest'
 
 afterEach(async () => {
   await act()

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,7 +1,7 @@
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 export default {
-    // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
-    // for more information about preprocessors
-    preprocess: vitePreprocess(),
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
 }


### PR DESCRIPTION
## Overview

This PR follows up the option cleanup of #325 with some test cleanup.

## Change log

- Remove an unnecessary cleanup test skip
- Remove a redundant `fireEvent` test
- Ensure `IS_SVELTE_5` from util is used in tests
- Align `console` mocks for consistency
- Replace `new Promise` for sleep with [`node:timers/promises`](https://nodejs.org/api/timers.html#timers-promises-api)
- Sort imports in tests when my editor yelled at me