### PR TITLE
fix: ensure fireEvent is exported

### DIFF
--- a/src/__tests__/events.test.js
+++ b/src/__tests__/events.test.js
@@ -1,6 +1,6 @@
+import { fireEvent, render } from '@testing-library/svelte'
 import { describe, expect, test } from 'vitest'
 
-import { fireEvent, render } from '@testing-library/svelte'
 import Comp from './fixtures/Comp.svelte'
 
 describe('events', () => {
@@ -8,8 +8,9 @@ describe('events', () => {
     const { getByText } = render(Comp, { props: { name: 'World' } })
     const button = getByText('Button')
 
-    await fireEvent.click(button)
+    const result = fireEvent.click(button)
 
+    await expect(result).resolves.toBe(true)
     expect(button).toHaveTextContent('Button Clicked')
   })
 
@@ -17,14 +18,15 @@ describe('events', () => {
     const { getByText } = render(Comp, { props: { name: 'World' } })
     const button = getByText('Button')
 
-    await fireEvent(
+    const result = fireEvent(
       button,
       new MouseEvent('click', {
         bubbles: true,
-        cancelable: true
+        cancelable: true,
       })
     )
 
+    await expect(result).resolves.toBe(true)
     expect(button).toHaveTextContent('Button Clicked')
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -13,5 +13,9 @@ if (typeof afterEach === 'function' && !process.env.STL_SKIP_AUTO_CLEANUP) {
   })
 }
 
-export * from './pure.js'
+// export all base queries, screen, etc.
 export * from '@testing-library/dom'
+
+// export svelte-specific functions and custom `fireEvent`
+// `fireEvent` must be a named export to take priority over wildcard export above
+export { act, cleanup, fireEvent, render } from './pure.js'

--- a/src/svelte5-index.js
+++ b/src/svelte5-index.js
@@ -13,6 +13,10 @@ if (typeof afterEach === 'function' && !process.env.STL_SKIP_AUTO_CLEANUP) {
   })
 }
 
-export { act, fireEvent } from './pure.js'
-export * from './svelte5.js'
+// export all base queries, screen, etc.
 export * from '@testing-library/dom'
+
+// export svelte-specific functions and custom `fireEvent`
+// `fireEvent` must be a named export to take priority over wildcard export above
+export { act, fireEvent } from './pure.js'
+export { cleanup, render } from './svelte5.js'

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
+import path from 'node:path'
+
 import { svelte } from '@sveltejs/vite-plugin-svelte'
-import path from 'path'
 import { VERSION as SVELTE_VERSION } from 'svelte/compiler'
 import { defineConfig } from 'vite'
 


### PR DESCRIPTION
## Overview

#328 moved exports from `pure.js` to `index.js` and switched everything to wildcard exports:

https://github.com/testing-library/svelte-testing-library/blob/0593819ca0e083eadf536d20d9d61944d594fb91/src/index.js#L15-L16

If two wildcard exports emit the same export, [neither will be included](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export). 

> There is also `export * from "mod"`, although there's no `import * from "mod"`. This re-exports all named exports from `mod` as the named exports of the current module, but the default export of `mod` is not re-exported. If there are two wildcard exports statements that implicitly re-export the same name, **neither one is re-exported**.

**This means the current release on `next` is not exporting `fireEvent`**. This PR moves the STL exports back to named exports to resolve the bug

## Observing the bug

```shell
pnpm add -D svelte @testing-library/svelte@next
node
> const stl = await import('@testing-library/svelte')
> stl.fireEvent
undefined
```

## Why didn't tests catch this?

Vite/Vitest appears to resolve exports differently from local files compared to `node_modules`. Since the test suite imports directly from `src/index.js`, the behavior is slightly different:

- The conflicting wildcard export of `fireEvent` is available
- It is set to whatever the _last_ export was

In our case, since `export * from '@testing-library/dom'` is listed second, that means the tests are running with the vanilla `fireEvent`, and coincidentally passing because a no-op `await` in the test was enough of a wait for Svelte to flush pending changes.

Without a more sophisticated test suite that packs and installs the library into example projects (which is a good long term idea!) this particular problem is hard to guard against with unit tests.

## Change log

- Update exports, with comments so we don't forget that the explicit named exports are important
- Update the tests to ensure `fireEvent` is returning a Promise
- Fix import/export sorting lint errors in files I was touching and looking at