### PR TITLE
ci: run weekly check with latest svelte versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, next]
   pull_request:
     branches: [main, next]
+  schedule:
+    # Tuesdays at 14:45 UTC (10:45 EST)
+    - cron: 45 14 * * 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR adds a scheduled event to CI to run the `main` job in the `release.yml` workflow weekly. Since the workflow always downloads the latest tagged version of the Svelte version under test, this should alert us of any breaks due to upstream changes