### PR TITLE
fix(svelte5): ensure proper `act` used in cleanup

### DIFF
--- a/src/svelte5-index.js
+++ b/src/svelte5-index.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/export */
-import { act, cleanup } from './svelte5.js'
+import { act } from './pure.js'
+import { cleanup } from './svelte5.js'
 
 // If we're running in a test runner that supports afterEach
 // then we'll automatically run cleanup afterEach test


### PR DESCRIPTION
Fix the issue noted in #342. Closely related to the issues fixed by #339, but I missed that that `act` was also wrong, because our own test suite does not trigger the auto-cleanup behavior