### PR TITLE
test: remove Svelte 5 + HappyDOM skips after bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-svelte": "2.35.1",
     "eslint-plugin-vitest-globals": "1.4.0",
     "expect-type": "^0.17.3",
-    "happy-dom": "^13.3.1",
+    "happy-dom": "^14.7.1",
     "jsdom": "^22.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "3.2.4",

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2,9 +2,8 @@ import { render } from '@testing-library/svelte'
 import { expect, test } from 'vitest'
 
 import Comp from './fixtures/Context.svelte'
-import { IS_HAPPYDOM, IS_SVELTE_5 } from './utils.js'
 
-test.skipIf(IS_SVELTE_5 && IS_HAPPYDOM)('can set a context', () => {
+test('can set a context', () => {
   const message = 'Got it'
 
   const { getByText } = render(Comp, {

--- a/src/__tests__/mount.test.js
+++ b/src/__tests__/mount.test.js
@@ -2,13 +2,12 @@ import { act, render, screen } from '@testing-library/svelte'
 import { describe, expect, test, vi } from 'vitest'
 
 import Mounter from './fixtures/Mounter.svelte'
-import { IS_HAPPYDOM, IS_SVELTE_5 } from './utils.js'
 
 const onMounted = vi.fn()
 const onDestroyed = vi.fn()
 const renderSubject = () => render(Mounter, { onMounted, onDestroyed })
 
-describe.skipIf(IS_SVELTE_5 && IS_HAPPYDOM)('mount and destroy', () => {
+describe('mount and destroy', () => {
   test('component is mounted', async () => {
     renderSubject()
 


### PR DESCRIPTION
Remove test skips now that https://github.com/capricorn86/happy-dom/pull/1393 has landed. Our Svelte 5 + happy-dom suite is now fully passing without any happy-dom specific skips

Closes #319