### PR TITLE
ci(dependabot): group dependency updates and reduce frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,33 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  # Update npm dependencies
+  - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: daily
-      time: '10:00'
-    open-pull-requests-limit: 10
+      interval: 'monthly'
+    groups:
+      lint:
+        patterns:
+          - '*eslint*'
+          - '*prettier*'
+          - '*typescript*'
+      test:
+        patterns:
+          - '*svelte*'
+          - '*testing-library*'
+          - '*vite*'
+          - '*vitest*'
+          - 'jsdom'
+          - 'happy-dom'
+      development:
+        dependency-type: 'development'
+
+  # Update GitHub Actions dependencies
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Overview

This PR is modeled after a change I made to ease maintenance of [npm-publish](https://github.com/JS-DevTools/npm-publish):

- Group dependabot updates into a few important "themes"
- Reduce PR frequency
- Add GitHub Actions update checking for better CI security

## Notes

- Monthly works well for a single-maintainer project, but maybe we can tolerate a higher frequency here!
    - I think the current PR backlog is a sign that daily is at least excessive
- I went of vibes for the groups; I like grouping linting and typechecking stuff into single PRs, because they tend to need each other, but other groups could be shifted and/or removed