### PR TITLE
ci(release): use semantic-release directly, add release preview script 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,24 +74,13 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: 📥 Download deps
         run: npm install --no-package-lock
 
       - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v2
-        with:
-          semantic_version: 17
-          branches: |
-            [
-              '+([0-9])?(.{+([0-9]),x}).x',
-              'main',
-              'next',
-              'next-major',
-              {name: 'beta', prerelease: true},
-              {name: 'alpha', prerelease: true}
-            ]
+        run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,22 @@
 
 ## Release
 
-The module is released automatically from the `main` branch using [semantic-release-action][]. Version bumps and change logs are generated from the commit messages.
+The module is released automatically from the `main` and `next` branches using [semantic-release][]. Version bumps and change logs are generated from the commit messages.
 
-[semantic-release-action]: https://github.com/cycjimmy/semantic-release-action
+[semantic-release]: https://github.com/semantic-release/semantic-release
+
+### Preview release
+
+If you would like to preview the release from a given branch, and...
+
+- You have push access to the repository
+- The branch exists in GitHub
+
+...you can preview the next release using:
+
+```shell
+npm run release:preview
+```
 
 ## Development setup
 

--- a/package.json
+++ b/package.json
@@ -46,12 +46,7 @@
     "end-to-end",
     "e2e"
   ],
-  "files": [
-    "src",
-    "types",
-    "!*.test-d.ts",
-    "!__tests__"
-  ],
+  "files": ["src", "types", "!*.test-d.ts", "!__tests__"],
   "scripts": {
     "toc": "doctoc README.md",
     "lint": "prettier . --check && eslint .",
@@ -71,7 +66,9 @@
     "types": "svelte-check",
     "validate": "npm-run-all test:vitest:* types",
     "contributors:add": "all-contributors add",
-    "contributors:generate": "all-contributors generate"
+    "contributors:generate": "all-contributors generate",
+    "release": "semantic-release",
+    "release:preview": "./scripts/preview-release"
   },
   "peerDependencies": {
     "svelte": "^3 || ^4 || ^5",
@@ -90,6 +87,7 @@
     "@testing-library/dom": "^10.0.0"
   },
   "devDependencies": {
+    "@semantic-release/exec": "^6.0.3",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/user-event": "^14.5.2",
@@ -114,6 +112,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "3.2.5",
     "prettier-plugin-svelte": "3.2.3",
+    "semantic-release": "^23.0.8",
     "svelte": "^3 || ^4 || ^5",
     "svelte-check": "^3.6.3",
     "svelte-jester": "^3.0.0",

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+  branches: [
+    '+([0-9])?(.{+([0-9]),x}).x',
+    'main',
+    'next',
+    'next-major',
+    { name: 'beta', prerelease: true },
+    { name: 'alpha', prerelease: true },
+  ],
+}

--- a/scripts/preview-release
+++ b/scripts/preview-release
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Preview the next release from a branch
+#
+# Prerequisites:
+# - You must have push access to repository at the `origin`  URL
+# - The branch you are on must exist on `origin`
+
+set -euxo pipefail
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+repository_url="$(git remote get-url origin)"
+
+semantic-release \
+  --plugins="@semantic-release/commit-analyzer,@semantic-release/release-notes-generator" \
+  --dry-run \
+  --branches="$branch" \
+  --repository-url="$repository_url"


### PR DESCRIPTION
## Overview

This PR updates the release configuration to use `semantic-release` directly rather than misdirect through a 3rd-party GitHub Action. By using `semantic-release` directly, we also gain the opportunity to do "dry run" releases locally.

Closes #356 (maybe?)

## Change log

- Add `semantic-release` to dev dependencies
- Update release step in CI workflow to simply call `semantic-release`
- Add `release:preview` script for maintainers to locally preview a release on a branch

## Release preview

I originally set out to get a "release preview" to be a part of the CI workflow. I ran into the following roadblocks with `semantic-release`:

- Must have push access to the repository
- Branch must exist on the remote

I threw myself at it a couple times, and walked away thinking that this just isn't something `semantic-release` is designed to do. So, I settled for something a little more crude that can hopefully still be helpful for maintainers - a local script:

```shell
npm run release:preview
```

Wen I run this on this branch, I get:

```
> @testing-library/svelte@0.0.0-semantically-released release:preview
> ./scripts/preview-release

++ git rev-parse --abbrev-ref HEAD
+ branch=semantic-release-dry-run
++ git remote get-url origin
+ repository_url=git@github.com:testing-library/svelte-testing-library.git
+ semantic-release --plugins=@semantic-release/commit-analyzer,@semantic-release/release-notes-generator --dry-run --branches=semantic-release-dry-run --repository-url=git@github.com:testing-library/svelte-testing-library.git
[1:22:57 AM] [semantic-release] › ℹ  Running semantic-release version 23.0.8
[1:22:57 AM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[1:22:57 AM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[1:23:06 AM] [semantic-release] › ⚠  Run automated release from branch semantic-release-dry-run on repository git@github.com:testing-library/svelte-testing-library.git in dry-run mode
[1:23:07 AM] [semantic-release] › ✔  Allowed to push to the Git repository
[1:23:07 AM] [semantic-release] › ℹ  Found git tag v5.1.0 associated with version 5.1.0 on branch semantic-release-dry-run
[1:23:08 AM] [semantic-release] › ℹ  Found 4 commits since last release
[1:23:08 AM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[1:23:08 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: ci(release): use `semantic-release` directly, add release preview script

Closes #356
[1:23:08 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
# ...more commits omitted to keep this PR description short...
[1:23:08 AM] [semantic-release] › ℹ  There are no relevant changes, so no new version is released.
```

