### PR TITLE
chore(deps): update vite-plugin-svelte to disable `hmr` in test

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.2",
+    "@sveltejs/vite-plugin-svelte": "^3.1.1",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@typescript-eslint/eslint-plugin": "7.8.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,7 +20,7 @@ const alias = [
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svelte({ hot: false }), svelteTesting()],
+  plugins: [svelte(), svelteTesting()],
   test: {
     alias,
     environment: 'jsdom',


### PR DESCRIPTION
Verifying that our test suite functions normally without us having to disable HMR ourselves with sveltejs/vite-plugin-svelte#913