### PR TITLE
ci(release): use conventionalcommits preset for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,8 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           semantic_version: 24
-          extra_plugins:
-            - conventional-changelog-conventionalcommits@8
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,8 @@ jobs:
     needs: main
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'testing-library/svelte-testing-library' &&
-      contains('refs/heads/main,refs/heads/beta,refs/heads/next,refs/heads/alpha',
-      github.ref) && github.event_name == 'push' }}
+      contains('refs/heads/main,refs/heads/next', github.ref) &&
+      github.event_name == 'push' }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
@@ -78,24 +78,14 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
-
-      - name: 📥 Download deps
-        run: npm install --no-package-lock
+          node-version: 20
 
       - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v4
         with:
-          semantic_version: 17
-          branches: |
-            [
-              '+([0-9])?(.{+([0-9]),x}).x',
-              'main',
-              'next',
-              'next-major',
-              {name: 'beta', prerelease: true},
-              {name: 'alpha', prerelease: true}
-            ]
+          semantic_version: 24
+          extra_plugins:
+            - conventional-changelog-conventionalcommits@8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@
 
 ## Release
 
-The module is released automatically from the `main` and `next` branches using [semantic-release][]. Version bumps and change logs are generated from the commit messages.
+The module is released automatically from the `main` and `next` branches using [semantic-release-action][]. Version bumps and change logs are generated from the commit messages.
 
-[semantic-release]: https://github.com/semantic-release/semantic-release
+[semantic-release-action]: https://github.com/cycjimmy/semantic-release-action
 
 ### Preview release
 
@@ -20,10 +20,10 @@ If you would like to preview the release from a given branch, and...
 - You have push access to the repository
 - The branch exists in GitHub
 
-...you can preview the next release using:
+...you can preview the next release version and changelog using:
 
 ```shell
-npm run release:preview
+npm run preview-release
 ```
 
 ## Development setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,22 @@
 
 ## Release
 
-The module is released automatically from the `main` branch using [semantic-release-action][]. Version bumps and change logs are generated from the commit messages.
+The module is released automatically from the `main` and `next` branches using [semantic-release][]. Version bumps and change logs are generated from the commit messages.
 
-[semantic-release-action]: https://github.com/cycjimmy/semantic-release-action
+[semantic-release]: https://github.com/semantic-release/semantic-release
+
+### Preview release
+
+If you would like to preview the release from a given branch, and...
+
+- You have push access to the repository
+- The branch exists in GitHub
+
+...you can preview the next release using:
+
+```shell
+npm run release:preview
+```
 
 ## Development setup
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:vitest:happy-dom": "vitest run --coverage --environment happy-dom",
     "test:jest": "npx --node-options=\"--experimental-vm-modules --no-warnings\" jest --coverage",
     "types": "svelte-check",
-    "validate": "npm-run-all test:vitest:* types",
+    "validate": "npm-run-all test:vitest:* test:jest types",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate"
   },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "types": "svelte-check",
     "validate": "npm-run-all test:vitest:* test:jest types",
     "contributors:add": "all-contributors add",
-    "contributors:generate": "all-contributors generate"
+    "contributors:generate": "all-contributors generate",
+    "preview-release": "./scripts/preview-release"
   },
   "peerDependencies": {
     "svelte": "^3 || ^4 || ^5",

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,4 @@
+export default {
+  preset: 'conventionalcommits',
+  branches: ['main', { name: 'next', prerelease: true }],
+}

--- a/scripts/preview-release
+++ b/scripts/preview-release
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Preview the next release from a branch
+#
+# Prerequisites:
+# - You must have push access to repository at the `origin`  URL
+# - The branch you are on must exist on `origin`
+
+set -euxo pipefail
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+repository_url="$(git remote get-url origin)"
+
+npx \
+  --package semantic-release@24 \
+  --package conventional-changelog-conventionalcommits@8 \
+  -- \
+  semantic-release \
+  --plugins="@semantic-release/commit-analyzer,@semantic-release/release-notes-generator" \
+  --dry-run \
+  --branches="$branch" \
+  --repository-url="$repository_url"


### PR DESCRIPTION
## Overview

This PR updates the semantic-release configuration for several maintenance improvements and simplifications.

Merging this PR into `next` just in case there are any issues

## Change log

- Use the `conventionalcommits` preset for version detection and changelog generations (closes #354)
- Add a simple `preview-release` script for maintainers (closes #356)
- Change `next` to a prerelease branch, remove other non-`main` branch configurations because we don't use them
