### PR TITLE
test(coverage): ensure proper files are included/excluded

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,4 +18,10 @@ export default {
   },
   resetMocks: true,
   restoreMocks: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*'],
+  coveragePathIgnorePatterns: [
+    '/__tests__/',
+    '<rootDir>/src/vite.js',
+    '<rootDir>/src/vitest.js',
+  ],
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,8 @@ export default defineConfig({
     unstubGlobals: true,
     coverage: {
       provider: 'v8',
-      include: ['src'],
+      include: ['src/**/*'],
+      exclude: ['**/__tests__/**', 'src/vite.js', 'src/vitest.js'],
     },
   },
 })


### PR DESCRIPTION
Coverage stats are a little off since fixing the codecov uploads. This PR fixes them up and aligns Jest and Vitest to collect from the same source files