### PR TITLE
fix(svelte5): synchronously flush changes after mount and unmount

### DIFF
--- a/src/__tests__/mount.test.js
+++ b/src/__tests__/mount.test.js
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/svelte'
+import { render, screen } from '@testing-library/svelte'
 import { describe, expect, test, vi } from 'vitest'
 
 import Mounter from './fixtures/Mounter.svelte'
@@ -14,20 +14,17 @@ describe('mount and destroy', () => {
     const content = screen.getByRole('button')
 
     expect(content).toBeInTheDocument()
-    await act()
     expect(onMounted).toHaveBeenCalledTimes(1)
   })
 
   test('component is destroyed', async () => {
     const { unmount } = renderSubject()
 
-    await act()
     unmount()
 
     const content = screen.queryByRole('button')
 
     expect(content).not.toBeInTheDocument()
-    await act()
     expect(onDestroyed).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/core/modern.svelte.js
+++ b/src/core/modern.svelte.js
@@ -26,6 +26,7 @@ const mount = (Component, options) => {
   const props = $state(options.props ?? {})
   const component = Svelte.mount(Component, { ...options, props })
 
+  Svelte.flushSync()
   propsByComponent.set(component, props)
 
   return component
@@ -34,7 +35,7 @@ const mount = (Component, options) => {
 /** Remove the component from the DOM. */
 const unmount = (component) => {
   propsByComponent.delete(component)
-  Svelte.unmount(component)
+  Svelte.flushSync(() => Svelte.unmount(component))
 }
 
 /**


### PR DESCRIPTION
Svelte 5 tests started failing in the mount/unmount tests. This PR adds a `flushSync` call to mount / unmount to ensure that components behave as users expect in a testing environment