### PR TITLE
ci: use production release of Svelte 5 by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: 📥 Download deps
-        run: |
-          npm install --no-package-lock
-          npm install --no-save svelte@${SVELTE_VERSION} @sveltejs/vite-plugin-svelte@${VITE_PLUGIN_VERSION}
-        env:
-          SVELTE_VERSION: ${{ matrix.svelte }}
-          VITE_PLUGIN_VERSION: ${{ matrix.svelte == '5' && '4' || matrix.svelte == '4' && '3' || '2' }}
+        run: ./scripts/install-dependencies ${{ matrix.svelte }}
 
       - name: ▶️ Run ${{ matrix.check }}
         run: npm run ${{ matrix.check }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           npm install --no-save svelte@${SVELTE_VERSION} @sveltejs/vite-plugin-svelte@${VITE_PLUGIN_VERSION}
         env:
           SVELTE_VERSION: ${{ matrix.svelte }}
-          VITE_PLUGIN_VERSION: ${{ matrix.svelte == '5' && '4' || '3' }}
+          VITE_PLUGIN_VERSION: ${{ matrix.svelte == '5' && '4' || matrix.svelte == '4' && '3' || '2' }}
 
       - name: ▶️ Run ${{ matrix.check }}
         run: npm run ${{ matrix.check }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
         include:
           # We only need to lint once, so do it on latest Node and Svelte
           - { node: '20', svelte: '4', check: 'lint' }
-          # `SvelteComponent` is not generic in Svelte 3, so type-checking only passes in >= 4
+          # Run type checks in latest node
+          - { node: '20', svelte: '3', check: 'types:legacy' }
           - { node: '20', svelte: '4', check: 'types:legacy' }
           - { node: '20', svelte: '5', check: 'types' }
           # Only run Svelte 5 checks on latest Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,11 @@ jobs:
           - { node: '20', svelte: '4', check: 'lint' }
           # `SvelteComponent` is not generic in Svelte 3, so type-checking only passes in >= 4
           - { node: '20', svelte: '4', check: 'types:legacy' }
-          - { node: '20', svelte: 'next', check: 'types' }
+          - { node: '20', svelte: '5', check: 'types' }
           # Only run Svelte 5 checks on latest Node
-          - { node: '20', svelte: 'next', check: 'test:vitest:jsdom' }
-          - { node: '20', svelte: 'next', check: 'test:vitest:happy-dom' }
-          - { node: '20', svelte: 'next', check: 'test:jest' }
+          - { node: '20', svelte: '5', check: 'test:vitest:jsdom' }
+          - { node: '20', svelte: '5', check: 'test:vitest:happy-dom' }
+          - { node: '20', svelte: '5', check: 'test:jest' }
 
     steps:
       - name: ⬇️ Checkout repo
@@ -53,7 +53,10 @@ jobs:
       - name: 📥 Download deps
         run: |
           npm install --no-package-lock
-          npm install --no-save svelte@${{ matrix.svelte }}
+          npm install --no-save svelte@${SVELTE_VERSION} @sveltejs/vite-plugin-svelte@${VITE_PLUGIN_VERSION}
+        env:
+          SVELTE_VERSION: ${{ matrix.svelte }}
+          VITE_PLUGIN_VERSION: ${{ matrix.svelte == '5' && '4' || '3' }}
 
       - name: ▶️ Run ${{ matrix.check }}
         run: npm run ${{ matrix.check }}

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@sveltejs/vite-plugin-svelte": "^3.1.1",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -111,7 +111,7 @@
     "eslint-plugin-promise": "^6.4.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-svelte": "^2.42.0",
-    "expect-type": "^0.20.0",
+    "expect-type": "^1.1.0",
     "happy-dom": "^15.7.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0",
+    "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/scripts/install-dependencies
+++ b/scripts/install-dependencies
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Install dependencies for a given version of Svelte
+set -euo pipefail
+
+svelte_version=${1}
+
+rm -rf node_modules
+npm install --no-package-lock
+
+if [[ "${svelte_version}" == "4" ]]; then
+  npm uninstall --no-save @sveltejs/vite-plugin-svelte svelte
+  npm install --no-save @sveltejs/vite-plugin-svelte@3 svelte@4
+elif [[ "${svelte_version}" == "3" ]]; then
+  npm uninstall --no-save vite vitest @vitest/coverage-v8 @sveltejs/vite-plugin-svelte svelte-check svelte
+  npm install --no-save vite@4 vitest@1 @vitest/coverage-v8@1 @sveltejs/vite-plugin-svelte@2 svelte-check@3 svelte@3
+fi
+
+npm ls --depth=0 svelte


### PR DESCRIPTION
## Overview

Now that Svelte 5 is released on the `latest` tag, this PR updates `package.json` and the CI config to use Svelte 5 by default

## Change log

- Bump default dev environment to Svelte 5
- Improve dependency installation for older Svelte versions in CI
- Enable type-checking on Svelte 3 in CI (enabled by better dependency installations)