### PR TITLE
fix(types): adjust legacy types for eslint-plugin-svelte

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,9 +26,12 @@ module.exports = {
     {
       files: ['*.ts'],
       parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: './tsconfig.json',
+      },
       extends: [
-        'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/stylistic',
+        'plugin:@typescript-eslint/strict-type-checked',
+        'plugin:@typescript-eslint/stylistic-type-checked',
         'prettier',
       ],
     },

--- a/src/__tests__/render.test-d.ts
+++ b/src/__tests__/render.test-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf } from 'expect-type'
+import { ComponentProps } from 'svelte'
 import { describe, test } from 'vitest'
 
 import * as subject from '../index.js'
@@ -35,5 +36,15 @@ describe('types', () => {
       rerender: (props: { name?: string; count?: number }) => Promise<void>
       unmount: () => void
     }>()
+  })
+
+  test('render function may be wrapped', () => {
+    const renderSubject = (props: ComponentProps<Component>) => {
+      return subject.render(Component, props)
+    }
+
+    renderSubject({ name: 'Alice', count: 42 })
+    // @ts-expect-error: name should be a string
+    renderSubject(Component, { name: 42 })
   })
 })

--- a/src/component-types.d.ts
+++ b/src/component-types.d.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents */
 import type * as Svelte from 'svelte'
 
-type IS_MODERN_SVELTE = any extends Svelte.Component ? false : true
+type IS_MODERN_SVELTE = Svelte.Component extends (...args: any[]) => any
+  ? true
+  : false
 
 /** A compiled, imported Svelte component. */
 export type Component<
@@ -14,12 +16,12 @@ export type Component<
 /**
  * The type of an imported, compiled Svelte component.
  *
- * In Svelte 4, this was the Svelte component class' type.
  * In Svelte 5, this distinction no longer matters.
+ * In Svelte 4, this is the Svelte component class constructor.
  */
-export type ComponentType<C> = C extends Svelte.SvelteComponent
-  ? Svelte.ComponentType<C>
-  : C
+export type ComponentType<C> = IS_MODERN_SVELTE extends true
+  ? C
+  : new (...args: any[]) => C
 
 /** The props of a component. */
 export type Props<C extends Component<any, any>> = Svelte.ComponentProps<C>
@@ -27,8 +29,8 @@ export type Props<C extends Component<any, any>> = Svelte.ComponentProps<C>
 /**
  * The exported fields of a component.
  *
- * In Svelte 4, this is simply the instance of the component class.
  * In Svelte 5, this is the set of variables marked as `export`'d.
+ * In Svelte 4, this is simply the instance of the component class.
  */
 export type Exports<C> = C extends Svelte.SvelteComponent
   ? C


### PR DESCRIPTION
When using `@testing-library/svelte@5.2.x` with Svelte 4, wrapping `render` can cause spurious `@typescript-eslint/no-unsafe-argument` errors. I suspect this is due to some sort of bug in `eslint-plugin-svelte`, but I have not yet produced a minimal reproduction.

```ts
import type { ComponentProps } from 'svelte';
import { render } from '@testing-library/svelte';

import Subject from '../app.svelte';

const renderSubject = (props: ComponentProps<Subject>) => {
  return render(Subject, props);
};
```

```
error  Unsafe argument of type `any` assigned to a parameter of type `SvelteComponentOptions<SvelteComponent<Record<string, any>, Record<string, any>, Record<string, any>>> | undefined`  @typescript-eslint/no-unsafe-argument
```

In the meantime, this PR

- Adjusts the types so that ESLint does not get mad
- Adds a failing test case to the types suite