### PR TITLE
refactor(core): consolidate options validation and cleanup into core

### DIFF
--- a/src/core/cleanup.js
+++ b/src/core/cleanup.js
@@ -1,0 +1,32 @@
+/** @type {Set<() => void>} */
+const cleanupTasks = new Set()
+
+/**
+ * Register later cleanup task
+ *
+ * @param {() => void} onCleanup
+ */
+const addCleanupTask = (onCleanup) => {
+  cleanupTasks.add(onCleanup)
+  return onCleanup
+}
+
+/**
+ * Remove a cleanup task without running it.
+ *
+ * @param {() => void} onCleanup
+ */
+const removeCleanupTask = (onCleanup) => {
+  cleanupTasks.delete(onCleanup)
+}
+
+/** Clean up all components and elements added to the document. */
+const cleanup = () => {
+  for (const handleCleanup of cleanupTasks.values()) {
+    handleCleanup()
+  }
+
+  cleanupTasks.clear()
+}
+
+export { addCleanupTask, cleanup, removeCleanupTask }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -5,15 +5,6 @@
  * Will switch to legacy, class-based mounting logic
  * if it looks like we're in a Svelte <= 4 environment.
  */
-import * as MountLegacy from './mount-legacy.js'
-import * as MountModern from './mount-modern.svelte.js'
-import { createValidateOptions } from './prepare.js'
-
-const { mount, unmount, updateProps, allowedOptions } =
-  MountModern.IS_MODERN_SVELTE ? MountModern : MountLegacy
-
-/** Validate component options. */
-const validateOptions = createValidateOptions(allowedOptions)
-
-export { mount, unmount, updateProps, validateOptions }
-export { UnknownSvelteOptionsError } from './prepare.js'
+export { cleanup } from './cleanup.js'
+export { mount } from './mount.js'
+export { prepare, UnknownSvelteOptionsError } from './prepare.js'

--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -1,0 +1,36 @@
+import { tick } from 'svelte'
+
+import * as MountLegacy from './mount-legacy.js'
+import * as MountModern from './mount-modern.svelte.js'
+
+const mountComponent = MountModern.IS_MODERN_SVELTE
+  ? MountModern.mount
+  : MountLegacy.mount
+
+/**
+ * Render a Svelte component into the document.
+ *
+ * @template {import('./types.js').Component} C
+ * @param {import('./types.js').ComponentType<C>} Component
+ * @param {import('./types.js').MountOptions<C>} options
+ * @returns {{
+ *   component: C
+ *   unmount: () => void
+ *   rerender: (props: Partial<import('./types.js').Props<C>>) => Promise<void>
+ * }}
+ */
+const mount = (Component, options = {}) => {
+  const { component, unmount, rerender } = mountComponent(Component, options)
+
+  return {
+    component,
+    unmount,
+    rerender: async (props) => {
+      rerender(props)
+      // Await the next tick for Svelte 4, which cannot flush changes synchronously
+      await tick()
+    },
+  }
+}
+
+export { mount }

--- a/src/core/prepare.js
+++ b/src/core/prepare.js
@@ -1,9 +1,18 @@
+import { addCleanupTask } from './cleanup.js'
+import * as MountLegacy from './mount-legacy.js'
+import * as MountModern from './mount-modern.svelte.js'
+
+const ALLOWED_OPTIONS = MountModern.IS_MODERN_SVELTE
+  ? MountModern.ALLOWED_OPTIONS
+  : MountLegacy.ALLOWED_OPTIONS
+
+/** An error thrown for incorrect options and clashes between props and Svelte options. */
 class UnknownSvelteOptionsError extends TypeError {
-  constructor(unknownOptions, allowedOptions) {
+  constructor(unknownOptions) {
     super(`Unknown options.
 
     Unknown: [ ${unknownOptions.join(', ')} ]
-    Allowed: [ ${allowedOptions.join(', ')} ]
+    Allowed: [ ${ALLOWED_OPTIONS.join(', ')} ]
 
     To pass both Svelte options and props to a component,
     or to use props that share a name with a Svelte option,
@@ -15,9 +24,41 @@ class UnknownSvelteOptionsError extends TypeError {
   }
 }
 
-const createValidateOptions = (allowedOptions) => (options) => {
+/**
+ * Prepare DOM elements for rendering.
+ *
+ * @template {import('./types.js').Component} C
+ * @param {import('./types.js').PropsOrMountOptions<C>} propsOrOptions
+ * @param {{ baseElement?: HTMLElement }} renderOptions
+ * @returns {{
+ *   baseElement: HTMLElement
+ *   target: HTMLElement
+ *   mountOptions: import('./types.js').MountOptions<C>
+ * }}
+ */
+const prepare = (propsOrOptions = {}, renderOptions = {}) => {
+  const mountOptions = validateMountOptions(propsOrOptions)
+
+  const baseElement =
+    renderOptions.baseElement ?? mountOptions.target ?? document.body
+
+  const target =
+    mountOptions.target ??
+    baseElement.appendChild(document.createElement('div'))
+
+  addCleanupTask(() => {
+    if (target.parentNode === document.body) {
+      document.body.removeChild(target)
+    }
+  })
+
+  return { baseElement, target, mountOptions: { ...mountOptions, target } }
+}
+
+/** Prevent incorrect options and clashes between props and Svelte options. */
+const validateMountOptions = (options) => {
   const isProps = !Object.keys(options).some((option) =>
-    allowedOptions.includes(option)
+    ALLOWED_OPTIONS.includes(option)
   )
 
   if (isProps) {
@@ -26,14 +67,14 @@ const createValidateOptions = (allowedOptions) => (options) => {
 
   // Check if any props and Svelte options were accidentally mixed.
   const unknownOptions = Object.keys(options).filter(
-    (option) => !allowedOptions.includes(option)
+    (option) => !ALLOWED_OPTIONS.includes(option)
   )
 
   if (unknownOptions.length > 0) {
-    throw new UnknownSvelteOptionsError(unknownOptions, allowedOptions)
+    throw new UnknownSvelteOptionsError(unknownOptions)
   }
 
   return options
 }
 
-export { createValidateOptions, UnknownSvelteOptionsError }
+export { prepare, UnknownSvelteOptionsError }

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -59,3 +59,8 @@ export type Exports<C> = IS_MODERN_SVELTE extends true
 export type MountOptions<C extends Component> = IS_MODERN_SVELTE extends true
   ? Parameters<typeof mount<Props<C>, Exports<C>>>[1]
   : LegacyConstructorOptions<Props<C>>
+
+/** Component props or partial mount options. */
+export type PropsOrMountOptions<C extends Component> =
+  | Props<C>
+  | Partial<MountOptions<C>>

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ if (typeof process !== 'undefined' && !process.env.STL_SKIP_AUTO_CLEANUP) {
 export * from '@testing-library/dom'
 
 // export svelte-specific functions and custom `fireEvent`
-export { UnknownSvelteOptionsError } from './core/index.js'
-export * from './pure.js'
 // `fireEvent` must be named to take priority over wildcard from @testing-library/dom
+export { UnknownSvelteOptionsError } from './core/index.js'
 export { fireEvent } from './pure.js'
+export * from './pure.js'


### PR DESCRIPTION
## Overview

The internal `core` module has got some potential usages outside of this library. It also could use a little bit of cleanup now that the dust has settled from the Svelte 5 launch.

## Change log

1. #411
2. (This PR) #412
3. ???