### PR TITLE
test: replace deprecated `toMatchTypeOf`

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "svelte-check": "^3.0.0 || ^4.0.4",
     "svelte-jester": "^5.0.0",
     "typescript": "^5.5.3",
+    "typescript-svelte-plugin": "^0.3.46",
     "vite": "^4.0.0 || ^5.3.3",
     "vitest": "0.x.x || ^1.0.0 || ^2.0.2"
   }

--- a/src/__tests__/render-runes.test-d.ts
+++ b/src/__tests__/render-runes.test-d.ts
@@ -29,7 +29,7 @@ describe('types', () => {
   test('render result has container and component', () => {
     const result = subject.render(Component, { name: 'Alice', count: 42 })
 
-    expectTypeOf(result).toMatchTypeOf<{
+    expectTypeOf(result).toExtend<{
       container: HTMLElement
       component: { hello: string }
       debug: (el?: HTMLElement) => void
@@ -55,7 +55,7 @@ describe('legacy component types', () => {
       count: 42,
     })
 
-    expectTypeOf(component).toMatchTypeOf<{ hello: string }>()
+    expectTypeOf(component).toExtend<{ hello: string }>()
 
     // @ts-expect-error: Svelte 5 mount does not return `$set`
     component.$on('greeting', onGreeting)

--- a/src/__tests__/render-utilities.test-d.ts
+++ b/src/__tests__/render-utilities.test-d.ts
@@ -8,7 +8,7 @@ describe('render query and utility types', () => {
   test('render result has default queries', () => {
     const result = subject.render(Component, { name: 'Alice' })
 
-    expectTypeOf(result.getByRole).parameters.toMatchTypeOf<
+    expectTypeOf(result.getByRole).parameters.toExtend<
       [role: subject.ByRoleMatcher, options?: subject.ByRoleOptions]
     >()
   })
@@ -27,25 +27,25 @@ describe('render query and utility types', () => {
       { queries: { getByVibes } }
     )
 
-    expectTypeOf(result.getByVibes).parameters.toMatchTypeOf<[vibes: string]>()
+    expectTypeOf(result.getByVibes).parameters.toExtend<[vibes: string]>()
   })
 
   test('act is an async function', () => {
-    expectTypeOf(subject.act).toMatchTypeOf<() => Promise<void>>()
+    expectTypeOf(subject.act).toExtend<() => Promise<void>>()
   })
 
   test('act accepts a sync function', () => {
-    expectTypeOf(subject.act).toMatchTypeOf<(fn: () => void) => Promise<void>>()
+    expectTypeOf(subject.act).toExtend<(fn: () => void) => Promise<void>>()
   })
 
   test('act accepts an async function', () => {
-    expectTypeOf(subject.act).toMatchTypeOf<
+    expectTypeOf(subject.act).toExtend<
       (fn: () => Promise<void>) => Promise<void>
     >()
   })
 
   test('fireEvent is an async function', () => {
-    expectTypeOf(subject.fireEvent).toMatchTypeOf<
+    expectTypeOf(subject.fireEvent).toExtend<
       (
         element: Element | Node | Document | Window,
         event: Event
@@ -54,7 +54,7 @@ describe('render query and utility types', () => {
   })
 
   test('fireEvent[eventName] is an async function', () => {
-    expectTypeOf(subject.fireEvent.click).toMatchTypeOf<
+    expectTypeOf(subject.fireEvent.click).toExtend<
       (
         element: Element | Node | Document | Window,
         // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/src/__tests__/render.test-d.ts
+++ b/src/__tests__/render.test-d.ts
@@ -37,7 +37,7 @@ describe('types', () => {
   test('render result has container and component', () => {
     const result = subject.render(Component, { name: 'Alice', count: 42 })
 
-    expectTypeOf(result).toMatchTypeOf<{
+    expectTypeOf(result).toExtend<{
       container: HTMLElement
       component: { hello: string }
       debug: (el?: HTMLElement) => void

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "noEmit": true,
     "skipLibCheck": true,
     "strict": true,
-    "types": ["svelte", "vite/client", "vitest", "vitest/globals"]
+    "types": ["svelte", "vite/client", "vitest", "vitest/globals"],
+    "plugins": [{ "name": "typescript-svelte-plugin" }]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Test-only change, good to merge if CI agrees. Also added `typescript-svelte-plugin` to `tsconfig.json` for better Zed editor support