### PR TITLE
fix: configure dom-testing-library to flush Svelte changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [This Solution](#this-solution)
 - [Installation](#installation)
 - [Setup](#setup)
+  - [Auto-cleanup](#auto-cleanup)
 - [Docs](#docs)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
@@ -139,6 +140,39 @@ test runners like Jest.
 
 [vitest]: https://vitest.dev/
 [setup docs]: https://testing-library.com/docs/svelte-testing-library/setup
+
+### Auto-cleanup
+
+In Vitest (via the `svelteTesting` plugin) and Jest (via the `beforeEach` and `afterEach` globals),
+this library will automatically setup and cleanup the test environment before and after each test.
+
+To do your own cleanup, or if you're using another framework, call the `setup` and `cleanup` functions yourself:
+
+```js
+import { cleanup, render, setup } from '@testing-library/svelte'
+
+// before
+setup()
+
+// test
+render(/* ... */)
+
+// after
+cleanup()
+```
+
+To disable auto-cleanup in Vitest, set the `autoCleanup` option of the plugin to false:
+
+```js
+svelteTesting({ autoCleanup: false })
+```
+
+To disable auto-cleanup in Jest and other frameworks with global test hooks,
+set the `STL_SKIP_AUTO_CLEANUP` environment variable:
+
+```shell
+STL_SKIP_AUTO_CLEANUP=1 jest
+```
 
 ## Docs
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ export default {
   extensionsToTreatAsEsm: ['.svelte'],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/tests/_jest-setup.js'],
-  injectGlobals: false,
+  injectGlobals: true,
   moduleNameMapper: {
     '^vitest$': '<rootDir>/tests/_jest-vitest-alias.js',
     [String.raw`^@testing-library\/svelte$`]: '<rootDir>/src/index.js',

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,22 @@
-import { act, cleanup } from './pure.js'
+import { act, cleanup, setup } from './pure.js'
 
-// If we're running in a test runner that supports afterEach
-// then we'll automatically run cleanup afterEach test
+// If we're running in a test runner that supports beforeEach/afterEach
+// we'll automatically run setup and cleanup before and after each test
 // this ensures that tests run in isolation from each other
 // if you don't like this then set the STL_SKIP_AUTO_CLEANUP env variable.
-if (typeof afterEach === 'function' && !process.env.STL_SKIP_AUTO_CLEANUP) {
-  afterEach(async () => {
-    await act()
-    cleanup()
-  })
+if (typeof process !== 'undefined' && !process.env.STL_SKIP_AUTO_CLEANUP) {
+  if (typeof beforeEach === 'function') {
+    beforeEach(() => {
+      setup()
+    })
+  }
+
+  if (typeof afterEach === 'function') {
+    afterEach(async () => {
+      await act()
+      cleanup()
+    })
+  }
 }
 
 // export all base queries, screen, etc.

--- a/src/vitest.js
+++ b/src/vitest.js
@@ -1,7 +1,11 @@
-import { act, cleanup } from '@testing-library/svelte'
-import { afterEach } from 'vitest'
+import { act, cleanup, setup } from '@testing-library/svelte'
+import { beforeEach } from 'vitest'
 
-afterEach(async () => {
-  await act()
-  cleanup()
+beforeEach(() => {
+  setup()
+
+  return async () => {
+    await act()
+    cleanup()
+  }
 })

--- a/tests/_jest-setup.js
+++ b/tests/_jest-setup.js
@@ -1,9 +1,1 @@
 import '@testing-library/jest-dom/jest-globals'
-
-import { afterEach } from '@jest/globals'
-import { act, cleanup } from '@testing-library/svelte'
-
-afterEach(async () => {
-  await act()
-  cleanup()
-})

--- a/tests/_jest-vitest-alias.js
+++ b/tests/_jest-vitest-alias.js
@@ -11,9 +11,10 @@ export {
   jest as vi,
 } from '@jest/globals'
 
-// Add support for describe.skipIf and test.skipIf
+// Add support for describe.skipIf, test.skipIf, and test.runIf
 describe.skipIf = (condition) => (condition ? describe.skip : describe)
 test.skipIf = (condition) => (condition ? test.skip : test)
+test.runIf = (condition) => (condition ? test : test.skip)
 
 // Add support for `stubGlobal`
 jest.stubGlobal = (property, stub) => {

--- a/tests/act.test.js
+++ b/tests/act.test.js
@@ -1,6 +1,7 @@
 import { setTimeout } from 'node:timers/promises'
 
 import { act, render, screen } from '@testing-library/svelte'
+import { userEvent } from '@testing-library/user-event'
 import { describe, expect, test } from 'vitest'
 
 import Comp from './fixtures/Comp.svelte'
@@ -24,9 +25,19 @@ describe('act', () => {
     const button = screen.getByText('Button')
 
     await act(async () => {
-      await setTimeout(100)
+      await setTimeout(10)
       button.click()
     })
+
+    expect(button).toHaveTextContent('Button Clicked')
+  })
+
+  test('wires act into user-event', async () => {
+    const user = userEvent.setup()
+    render(Comp)
+    const button = screen.getByText('Button')
+
+    await user.click(button)
 
     expect(button).toHaveTextContent('Button Clicked')
   })

--- a/tests/auto-cleanup.test.js
+++ b/tests/auto-cleanup.test.js
@@ -6,15 +6,18 @@ import { IS_JEST } from './_env.js'
 // in Jest breaks Svelte's environment checking heuristics.
 // Re-implement this test in a more accurate environment, without mocks.
 describe.skipIf(IS_JEST)('auto-cleanup', () => {
+  const globalBeforeEach = vi.fn()
   const globalAfterEach = vi.fn()
 
   beforeEach(() => {
     vi.resetModules()
+    globalThis.beforeEach = globalBeforeEach
     globalThis.afterEach = globalAfterEach
   })
 
   afterEach(() => {
     delete process.env.STL_SKIP_AUTO_CLEANUP
+    delete globalThis.beforeEach
     delete globalThis.afterEach
   })
 
@@ -37,6 +40,7 @@ describe.skipIf(IS_JEST)('auto-cleanup', () => {
 
     await import('@testing-library/svelte')
 
+    expect(globalBeforeEach).toHaveBeenCalledTimes(0)
     expect(globalAfterEach).toHaveBeenCalledTimes(0)
   })
 })

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -1,6 +1,8 @@
+import { fireEvent as fireEventDTL } from '@testing-library/dom'
 import { fireEvent, render, screen } from '@testing-library/svelte'
 import { describe, expect, test } from 'vitest'
 
+import { IS_SVELTE_5 } from './_env.js'
 import Comp from './fixtures/Comp.svelte'
 
 describe('events', () => {
@@ -27,6 +29,16 @@ describe('events', () => {
     )
 
     await expect(result).resolves.toBe(true)
+    expect(button).toHaveTextContent('Button Clicked')
+  })
+
+  test.runIf(IS_SVELTE_5)('state changes are flushed synchronously', () => {
+    render(Comp, { props: { name: 'World' } })
+    const button = screen.getByText('Button')
+
+    const result = fireEventDTL.click(button)
+
+    expect(result).toBe(true)
     expect(button).toHaveTextContent('Button Clicked')
   })
 })


### PR DESCRIPTION
## Overview

While working on new examples for Svelte 5, I found a problem with this library's interop with `@testing-library/user-event` - depending on project setup, `await user.click()` et. al. does not wait for Svelte to flush changes.

We were missing a call to `configure` to `@testing-library/dom` to configure the `eventWrapper` (for `fireEvent`) and `asyncWrapper` (for `user-event`) options. This fixes the issue for `user-event`, and happily, removes the need for an async re-export of `fireEvent` once we're able to drop Svelte 3/4, thanks to the new `flushSync` export from `svelte`

Related (old) issue: #250

## Change log

- Add `setup` function to complement `cleanup` function that calls `@testing-library/dom::configure` with `tick` and `flushSync`
- Wire `setup` into `beforeEach` for Jest and Vitest
- Add cleanup setup to setup docs in README