### PR TITLE
feat: add wrapper option

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -5,4 +5,5 @@
 - [Snippets](./snippets)
 - [Contexts](./contexts)
 - [Binds](./binds)
+- [Wrappers]('./wrappers)
 - [Deprecated Svelte 3 and 4 features](./deprecated)

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -5,5 +5,5 @@
 - [Snippets](./snippets)
 - [Contexts](./contexts)
 - [Binds](./binds)
-- [Wrappers]('./wrappers)
+- [Wrappers](./wrappers)
 - [Deprecated Svelte 3 and 4 features](./deprecated)

--- a/examples/wrappers/child.svelte
+++ b/examples/wrappers/child.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { getContext } from 'svelte'
+
+  let { label } = $props()
+
+  const messages = getContext('messages')
+</script>
+
+<div role="status" aria-label={label}>
+  {#each messages.current as message (message.id)}
+    <p>{message.text}</p>
+    <hr />
+  {/each}
+</div>

--- a/examples/wrappers/child.test.js
+++ b/examples/wrappers/child.test.js
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/svelte'
+import { expect, test } from 'vitest'
+
+import Subject from './child.svelte'
+import Wrapper from './wrapper.svelte'
+
+test('notifications with messages from context', () => {
+  const messages = [
+    { id: 'abc', text: 'hello' },
+    { id: 'def', text: 'world' },
+  ]
+
+  render(
+    Subject,
+    { label: 'Notifications' },
+    { wrapper: Wrapper, wrapperProps: { messages } }
+  )
+
+  const status = screen.getByRole('status', { name: 'Notifications' })
+
+  expect(status).toHaveTextContent('hello world')
+})

--- a/examples/wrappers/readme.md
+++ b/examples/wrappers/readme.md
@@ -1,0 +1,87 @@
+# Wrappers
+
+Sometimes, a component cannot properly render or operate unless it's the child
+of another component. To wrap your component under test in a parent, use the
+`wrapper` and `wrapperProps` options.
+
+> \[!TIP]
+>
+> If you can't test a component in isolation, this may be a sign that you're
+> testing at the wrong level, or that your component structure should be
+> rethought. Consider if you can make your components more testable in isolation
+> before reaching for this option.
+
+While this example uses context to demonstrate the usage of the `wrapper`
+options, if you have access to the context directly, not through a provider
+component, then the [`context` option](../contexts) is a better choice than
+`wrapper`.
+
+## Table of contents
+
+- [`wrapper.svelte`](#wrappersvelte)
+- [`child.svelte`](#childsvelte)
+- [`child.test.js`](#childtestjs)
+
+## `wrapper.svelte`
+
+```svelte file=./wrapper.svelte
+<script>
+  import { setContext } from 'svelte'
+
+  let { messages, children } = $props()
+
+  setContext('messages', {
+    get current() {
+      return messages
+    },
+  })
+</script>
+
+{@render children?.()}
+```
+
+## `child.svelte`
+
+```svelte file=./child.svelte
+<script>
+  import { getContext } from 'svelte'
+
+  let { label } = $props()
+
+  const messages = getContext('messages')
+</script>
+
+<div role="status" aria-label={label}>
+  {#each messages.current as message (message.id)}
+    <p>{message.text}</p>
+    <hr />
+  {/each}
+</div>
+```
+
+## `child.test.js`
+
+```js file=./child.test.js
+import { render, screen } from '@testing-library/svelte'
+import { expect, test } from 'vitest'
+
+import Subject from './child.svelte'
+import Wrapper from './wrapper.svelte'
+
+test('notifications with messages from context', () => {
+  const messages = [
+    { id: 'abc', text: 'hello' },
+    { id: 'def', text: 'world' },
+  ]
+
+  render(
+    Subject,
+    { label: 'Notifications' },
+    { wrapper: Wrapper, wrapperProps: { messages } }
+  )
+
+  const status = screen.getByRole('status', { name: 'Notifications' })
+
+  expect(status).toHaveTextContent('hello world')
+})
+```

--- a/examples/wrappers/wrapper.svelte
+++ b/examples/wrappers/wrapper.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { setContext } from 'svelte'
+
+  let { messages, children } = $props()
+
+  setContext('messages', {
+    get current() {
+      return messages
+    },
+  })
+</script>
+
+{@render children?.()}

--- a/packages/svelte-core/README.md
+++ b/packages/svelte-core/README.md
@@ -68,19 +68,20 @@ const { baseElement, container, component, rerender, unmount } = render(
 )
 ```
 
-| Argument           | Type                                                    | Description                                   |
-| ------------------ | ------------------------------------------------------- | --------------------------------------------- |
-| `Component`        | [Svelte component][svelte-component-docs]               | An imported Svelte component                  |
-| `componentOptions` | `Props` or partial [`mount` options][svelte-mount-docs] | Options for how the component will be mounted |
-| `setupOptions`     | `{ baseElement?: HTMLElement }`                         | Optionally override `baseElement`             |
+| Argument           | Type                                                    | Description                                             |
+| ------------------ | ------------------------------------------------------- | ------------------------------------------------------- |
+| `Component`        | [Svelte component][svelte-component-docs]               | An imported Svelte component                            |
+| `componentOptions` | `Props` or partial [`mount` options][svelte-mount-docs] | Options for how the component will be mounted           |
+| `setupOptions`     | [`SetupOptions`](#setup)                                | Optionally override `baseElement` or wrap the component |
 
-| Result        | Type                                       | Description                              | Default                             |
-| ------------- | ------------------------------------------ | ---------------------------------------- | ----------------------------------- |
-| `baseElement` | `HTMLElement`                              | The base element                         | `document.body`                     |
-| `container`   | `HTMLElement`                              | The component's immediate parent element | `<div>` appended to `document.body` |
-| `component`   | [component exports][svelte-mount-docs]     | The component's exports from `mount`     | N/A                                 |
-| `rerender`    | `(props: Partial<Props>) => Promise<void>` | Update the component's props             | N/A                                 |
-| `unmount`     | `() => void`                               | Unmount the component from the document  | N/A                                 |
+| Result        | Type                                       | Description                                        | Default                             |
+| ------------- | ------------------------------------------ | -------------------------------------------------- | ----------------------------------- |
+| `baseElement` | `HTMLElement`                              | The base element                                   | `document.body`                     |
+| `container`   | `HTMLElement`                              | The component's immediate parent element           | `<div>` appended to `document.body` |
+| `component`   | [component exports][svelte-mount-docs]     | The component's exports from `mount`               | N/A                                 |
+| `wrapper`     | [component exports][svelte-mount-docs]     | The wrapper's exports, if a `wrapper` was provided | `undefined`                         |
+| `rerender`    | `(props: Partial<Props>) => Promise<void>` | Update the component's props                       | N/A                                 |
+| `unmount`     | `() => void`                               | Unmount the component from the document            | N/A                                 |
 
 > \[!TIP]
 > Calling `render` is equivalent to calling [`setup`](#setup) followed by [`mount`](#mount)
@@ -90,7 +91,11 @@ const { baseElement, container, component, rerender, unmount } = render(
 >   componentOptions,
 >   setupOptions
 > )
-> const { component, rerender, unmount } = mount(Component, mountOptions)
+> const { component, rerender, unmount } = mount(
+>   Component,
+>   mountOptions,
+>   setupOptions
+> )
 > ```
 
 [svelte-component-docs]: https://svelte.dev/docs/svelte-components
@@ -110,7 +115,15 @@ const { baseElement, container, mountOptions } = setup(
 | Argument           | Type                                                    | Description                                   |
 | ------------------ | ------------------------------------------------------- | --------------------------------------------- |
 | `componentOptions` | `Props` or partial [`mount` options][svelte-mount-docs] | Options for how the component will be mounted |
-| `setupOptions`     | `{ baseElement?: HTMLElement }`                         | Optionally override `baseElement`             |
+| `setupOptions`     | `SetupOptions`                                          | Configure the document and wrap the component |
+
+`setupOptions` accepts the following fields, all optional:
+
+| Field          | Type                                      | Description                                                           | Default         |
+| -------------- | ----------------------------------------- | --------------------------------------------------------------------- | --------------- |
+| `baseElement`  | `HTMLElement`                             | The base element to bind queries to                                   | `document.body` |
+| `wrapper`      | [Svelte component][svelte-component-docs] | A component to wrap the component under test, e.g. a context provider | `undefined`     |
+| `wrapperProps` | `Props`                                   | Props to pass to the `wrapper` component                              | `undefined`     |
 
 | Result         | Type                                 | Description                              | Default                             |
 | -------------- | ------------------------------------ | ---------------------------------------- | ----------------------------------- |
@@ -123,19 +136,25 @@ const { baseElement, container, mountOptions } = setup(
 Mount a Svelte component into the document.
 
 ```ts
-const { component, unmount, rerender } = mount(Component, mountOptions)
+const { component, wrapper, unmount, rerender } = mount(
+  Component,
+  mountOptions,
+  setupOptions
+)
 ```
 
-| Argument       | Type                                      | Description                                  |
-| -------------- | ----------------------------------------- | -------------------------------------------- |
-| `Component`    | [Svelte component][svelte-component-docs] | An imported Svelte component                 |
-| `mountOptions` | [component options][svelte-mount-docs]    | Options to pass to Svelte's `mount` function |
+| Argument       | Type                                      | Description                                               |
+| -------------- | ----------------------------------------- | --------------------------------------------------------- |
+| `Component`    | [Svelte component][svelte-component-docs] | An imported Svelte component                              |
+| `mountOptions` | [component options][svelte-mount-docs]    | Options to pass to Svelte's `mount` function              |
+| `setupOptions` | [`SetupOptions`](#setup)                  | Optionally wrap the component (`wrapper`, `wrapperProps`) |
 
-| Result      | Type                                       | Description                             |
-| ----------- | ------------------------------------------ | --------------------------------------- |
-| `component` | [component exports][svelte-mount-docs]     | The component's exports from `mount`    |
-| `unmount`   | `() => void`                               | Unmount the component from the document |
-| `rerender`  | `(props: Partial<Props>) => Promise<void>` | Update the component's props            |
+| Result      | Type                                       | Description                                        |
+| ----------- | ------------------------------------------ | -------------------------------------------------- |
+| `component` | [component exports][svelte-mount-docs]     | The component's exports from `mount`               |
+| `wrapper`   | [component exports][svelte-mount-docs]     | The wrapper's exports, if a `wrapper` was provided |
+| `unmount`   | `() => void`                               | Unmount the component from the document            |
+| `rerender`  | `(props: Partial<Props>) => Promise<void>` | Update the component's props                       |
 
 ### `cleanup`
 

--- a/packages/svelte-core/src/mount.js
+++ b/packages/svelte-core/src/mount.js
@@ -113,7 +113,7 @@ const setupComponent = (Component, mountOptions, setupOptions = {}) => {
         ...mountOptions,
         props: {
           wrapper: unwrapComponentImport(wrapper),
-          wrapperProps: wrapperProps,
+          wrapperProps,
           component: componentToMount,
           componentProps: mountOptions.props,
         },

--- a/packages/svelte-core/src/mount.js
+++ b/packages/svelte-core/src/mount.js
@@ -6,6 +6,7 @@ import * as Svelte from 'svelte'
 import { addCleanupTask, removeCleanupTask } from './cleanup.js'
 import { createProps } from './props.svelte.js'
 import { IS_MODERN_SVELTE } from './svelte-version.js'
+import WrapperScaffold from './wrapper-scaffold.svelte'
 
 /**
  * Mount a modern Svelte 5 component into the DOM.
@@ -74,21 +75,81 @@ const mountLegacy = (Component, options) => {
 const mountComponent = IS_MODERN_SVELTE ? mountModern : mountLegacy
 
 /**
+ * Extract a component from an import.
+ *
+ * Allows a dynamic `import('component.svelte')` to be used
+ * for component values.
+ *
+ * @template {import('../types.js').Component} C
+ * @param {import('../types.js').ComponentImport<C>} componentImport
+ * @returns {import('../types.js').ComponentType<C>}
+ */
+const unwrapComponentImport = (componentImport) => {
+  return 'default' in componentImport
+    ? componentImport.default
+    : componentImport
+}
+
+/**
  * Render a Svelte component into the document.
  *
  * @template {import('../types.js').Component} C
+ * @template {import('../types.js').Component} [W=never]
+ *
+ * @param {import('../types.js').ComponentImport<C>} Component
+ * @param {import('../types.js').MountOptions<C>} mountOptions
+ * @param {import('../types.js').SetupOptions<W>} [setupOptions]
+ * @returns {{componentToMount: import('../types.js').ComponentType<C | W>, mountOptions: import('../types.js').MountOptions<C | W>, isWrapper: boolean}}
+ */
+const setupComponent = (Component, mountOptions, setupOptions = {}) => {
+  const componentToMount = unwrapComponentImport(Component)
+  const { wrapper, wrapperProps } = setupOptions
+
+  if (wrapper) {
+    return {
+      isWrapper: true,
+      componentToMount: WrapperScaffold,
+      mountOptions: {
+        ...mountOptions,
+        props: {
+          wrapper: unwrapComponentImport(wrapper),
+          wrapperProps: wrapperProps,
+          component: componentToMount,
+          componentProps: mountOptions.props,
+        },
+      },
+    }
+  }
+
+  return { isWrapper: false, componentToMount, mountOptions }
+}
+
+/**
+ * Render a Svelte component into the document.
+ *
+ * @template {import('../types.js').Component} C
+ * @template {import('../types.js').Component} [W=never]
+ *
  * @param {import('../types.js').ComponentImport<C>} Component
  * @param {import('../types.js').MountOptions<C>} options
+ * @param {import('../types.js').SetupOptions<W>} [setupOptions]
  * @returns {import('../types.js').MountResult<C>}
  */
-const mount = (Component, options) => {
+const mount = (Component, options, setupOptions = {}) => {
+  const { componentToMount, mountOptions, isWrapper } = setupComponent(
+    Component,
+    options,
+    setupOptions
+  )
+
   const { component, unmount, rerender } = mountComponent(
-    'default' in Component ? Component.default : Component,
-    options
+    componentToMount,
+    mountOptions
   )
 
   return {
-    component,
+    component: isWrapper ? component.getComponent() : component,
+    wrapper: isWrapper ? component.getWrapper() : undefined,
     unmount,
     rerender: async (props) => {
       if ('props' in props) {
@@ -96,6 +157,12 @@ const mount = (Component, options) => {
           'rerender({ props: { ... } }) deprecated, use rerender({ ... }) instead'
         )
         props = props.props
+      }
+
+      if (isWrapper) {
+        props = {
+          componentProps: { ...component.getComponentProps(), ...props },
+        }
       }
 
       rerender(props)

--- a/packages/svelte-core/src/render.js
+++ b/packages/svelte-core/src/render.js
@@ -5,15 +5,16 @@ import { setup } from './setup.js'
  * Render a component into the document.
  *
  * @template {import('../types.js').Component} C
+ * @template {import('../types.js').Component} [W=never]
  *
  * @param {import('../types.js').ComponentImport<C>} Component - The component to render.
  * @param {import('../types.js').ComponentOptions<C>} componentOptions - Customize how Svelte renders the component.
- * @param {import('../types.js').SetupOptions} setupOptions - Customize how the document is set up.
- * @returns {import('../types.js').RenderResult<C>} The rendered component.
+ * @param {import('../types.js').SetupOptions<W>} setupOptions - Customize how the document and component is set up.
+ * @returns {import('../types.js').RenderResult<C, W>} The rendered component.
  */
 const render = (Component, componentOptions, setupOptions = {}) => {
   const { mountOptions, ...setupResult } = setup(componentOptions, setupOptions)
-  const mountResult = mount(Component, mountOptions)
+  const mountResult = mount(Component, mountOptions, setupOptions)
 
   return { ...setupResult, ...mountResult }
 }

--- a/packages/svelte-core/src/setup.js
+++ b/packages/svelte-core/src/setup.js
@@ -56,11 +56,10 @@ const validateOptions = (options) => {
  * Set up the document to render a component.
  *
  * @template {import('../types.js').Component} C
- * @template {import('../types.js').Component} [W=never]
  *
  * @param {import('../types.js').ComponentOptions<C>} componentOptions - props or mount options
- * @param {import('../types.js').SetupOptions<W>} setupOptions - base element of the document to bind any queries
- * @returns {import('../types.js').SetupResult<C, W>}
+ * @param {import('../types.js').SetupOptions<any>} setupOptions - base element of the document to bind any queries
+ * @returns {import('../types.js').SetupResult<C>}
  */
 const setup = (componentOptions, setupOptions = {}) => {
   const mountOptions = validateOptions(componentOptions)

--- a/packages/svelte-core/src/setup.js
+++ b/packages/svelte-core/src/setup.js
@@ -56,9 +56,11 @@ const validateOptions = (options) => {
  * Set up the document to render a component.
  *
  * @template {import('../types.js').Component} C
+ * @template {import('../types.js').Component} [W=never]
+ *
  * @param {import('../types.js').ComponentOptions<C>} componentOptions - props or mount options
- * @param {import('../types.js').SetupOptions} setupOptions - base element of the document to bind any queries
- * @returns {import('../types.js').SetupResult<C>}
+ * @param {import('../types.js').SetupOptions<W>} setupOptions - base element of the document to bind any queries
+ * @returns {import('../types.js').SetupResult<C, W>}
  */
 const setup = (componentOptions, setupOptions = {}) => {
   const mountOptions = validateOptions(componentOptions)

--- a/packages/svelte-core/src/wrapper-scaffold.svelte
+++ b/packages/svelte-core/src/wrapper-scaffold.svelte
@@ -1,0 +1,21 @@
+<script>
+  export let wrapper
+  export let wrapperProps
+  export let component
+  export let componentProps
+
+  let wrapperInstance
+  let componentInstance
+
+  export const getWrapper = () => wrapperInstance
+  export const getComponent = () => componentInstance
+  export const getComponentProps = () => componentProps
+</script>
+
+<svelte:component this={wrapper} bind:this={wrapperInstance} {...wrapperProps}>
+  <svelte:component
+    this={component}
+    bind:this={componentInstance}
+    {...componentProps}
+  />
+</svelte:component>

--- a/packages/svelte-core/types.d.ts
+++ b/packages/svelte-core/types.d.ts
@@ -91,19 +91,25 @@ export type Rerender<C extends Component> = (
 ) => Promise<void>
 
 /** The result of mounting a component into the document. */
-export interface MountResult<C extends Component> {
+export interface MountResult<C extends Component, W extends Component = never> {
   /** The mounted component's exports. */
   component: Exports<C>
+  /** The mounted wrapper's exports, if a wrapper was provided. */
+  wrapper: Exports<W>
   /** Unmount the component. */
   unmount: () => void
   /** Rerender the component. */
   rerender: Rerender<C>
 }
 
-/** Options for configuring the document. */
-export interface SetupOptions {
+/** Options for configuring the component and document. */
+export interface SetupOptions<W extends Component = never> {
   /** The base document element, `document.body` if unspecified. */
   baseElement?: HTMLElement
+  /** A wrapper component. */
+  wrapper?: ComponentImport<W>
+  /** Wrapper component props. */
+  wrapperProps?: Props<W>
 }
 
 /** The result of setting up the document for rendering. */
@@ -117,13 +123,18 @@ export interface SetupResult<C extends Component> {
 }
 
 /** The result of setting up the document and rendering the component. */
-export interface RenderResult<C extends Component> {
+export interface RenderResult<
+  C extends Component,
+  W extends Component = never,
+> {
   /** The base document element, usually `document.body`. */
   baseElement: HTMLElement
   /** The component's immediate container element, usually a `<div>` appended to `document.body`. */
   container: HTMLElement
   /** The mounted component's exports. */
   component: Exports<C>
+  /** The mounted wrapper's exports, if a wrapper was provided. */
+  wrapper: Exports<W>
   /** Unmount the component. */
   unmount: () => void
   /** Rerender the component. */

--- a/packages/svelte/src/pure.js
+++ b/packages/svelte/src/pure.js
@@ -13,7 +13,8 @@ import * as Svelte from 'svelte'
  * Customize how Testing Library sets up the document and binds queries.
  *
  * @template {DomTestingLibrary.Queries} [Q=typeof DomTestingLibrary.queries]
- * @typedef {import('@testing-library/svelte-core/types').SetupOptions & { queries?: Q }} RenderOptions
+ * @template {import('@testing-library/svelte-core/types').Component} [W=never]
+ * @typedef {import('@testing-library/svelte-core/types').SetupOptions<W> & { queries?: Q }} RenderOptions
  */
 
 /**
@@ -21,11 +22,13 @@ import * as Svelte from 'svelte'
  *
  * @template {import('@testing-library/svelte-core/types').Component} C
  * @template {DomTestingLibrary.Queries} [Q=typeof DomTestingLibrary.queries]
+ * @template {import('@testing-library/svelte-core/types').Component} [W=never]
  *
  * @typedef {{
  *   container: HTMLElement
  *   baseElement: HTMLElement
  *   component: import('@testing-library/svelte-core/types').Exports<C>
+ *   wrapper: import('@testing-library/svelte-core/types').Exports<W>
  *   debug: (el?: HTMLElement | DocumentFragment) => void
  *   rerender: import('@testing-library/svelte-core/types').Rerender<C>
  *   unmount: () => void
@@ -39,18 +42,16 @@ import * as Svelte from 'svelte'
  *
  * @template {import('@testing-library/svelte-core/types').Component} C
  * @template {DomTestingLibrary.Queries} [Q=typeof DomTestingLibrary.queries]
+ * @template {import('@testing-library/svelte-core/types').Component} [W=never]
  *
  * @param {import('@testing-library/svelte-core/types').ComponentImport<C>} Component - The component to render.
  * @param {import('@testing-library/svelte-core/types').ComponentOptions<C>} options - Customize how Svelte renders the component.
- * @param {RenderOptions<Q>} renderOptions - Customize how Testing Library sets up the document and binds queries.
- * @returns {RenderResult<C, Q>} The rendered component and bound testing functions.
+ * @param {RenderOptions<Q, W>} renderOptions - Customize how Testing Library sets up the document and binds queries.
+ * @returns {RenderResult<C, Q, W>} The rendered component and bound testing functions.
  */
 const render = (Component, options = {}, renderOptions = {}) => {
-  const { baseElement, container, component, unmount, rerender } = Core.render(
-    Component,
-    options,
-    renderOptions
-  )
+  const { baseElement, container, component, wrapper, unmount, rerender } =
+    Core.render(Component, options, renderOptions)
 
   const queries = DomTestingLibrary.getQueriesForElement(
     baseElement,
@@ -61,6 +62,7 @@ const render = (Component, options = {}, renderOptions = {}) => {
     baseElement,
     container,
     component,
+    wrapper,
     rerender,
     unmount,
     debug: (el = baseElement) => console.log(DomTestingLibrary.prettyDOM(el)),

--- a/tests/_env.js
+++ b/tests/_env.js
@@ -24,3 +24,7 @@ export const COMPONENT_FIXTURES = [
     isEnabled: IS_SVELTE_5,
   },
 ].filter(({ isEnabled }) => isEnabled)
+
+export const WRAPPER = IS_SVELTE_5
+  ? './fixtures/WrapperRunes.svelte'
+  : './fixtures/Wrapper.svelte'

--- a/tests/fixtures/Wrapped.svelte
+++ b/tests/fixtures/Wrapped.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { getContext } from 'svelte'
+
+  export let name
+  export let punctuation = '.'
+  export let value = ''
+
+  export const wrappedContext = getContext('wrapperContext')
+</script>
+
+<p data-testid="context">{wrappedContext.greeting} {name}{punctuation}</p>
+<input type="text" bind:value />

--- a/tests/fixtures/Wrapper.svelte
+++ b/tests/fixtures/Wrapper.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { setContext } from 'svelte'
+
+  export let greeting
+
+  export const wrapperContext = {
+    get greeting() {
+      return greeting
+    },
+  }
+
+  setContext('wrapperContext', wrapperContext)
+</script>
+
+<div data-testid="wrapper"><slot /></div>

--- a/tests/fixtures/WrapperRunes.svelte
+++ b/tests/fixtures/WrapperRunes.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { setContext } from 'svelte'
+
+  const { greeting, children } = $props()
+
+  export const wrapperContext = {
+    get greeting() {
+      return greeting
+    },
+  }
+
+  setContext('wrapperContext', wrapperContext)
+</script>
+
+<div data-testid="wrapper-runes">
+  {@render children?.()}
+</div>

--- a/tests/render-runes.test-d.ts
+++ b/tests/render-runes.test-d.ts
@@ -2,10 +2,11 @@ import * as subject from '@testing-library/svelte'
 import { expectTypeOf } from 'expect-type'
 import { describe, test, vi } from 'vitest'
 
+import UntypedComponent from './fixtures/Comp.svelte'
 import LegacyComponent from './fixtures/Typed.svelte'
 import Component from './fixtures/TypedRunes.svelte'
 
-describe('types', () => {
+describe('types (runes)', () => {
   test('render is a function that accepts a Svelte component', () => {
     subject.render(Component, { name: 'Alice', count: 42 })
     subject.render(Component, { props: { name: 'Alice', count: 42 } })
@@ -32,10 +33,30 @@ describe('types', () => {
     expectTypeOf(result).toExtend<{
       container: HTMLElement
       component: { hello: string }
+      wrapper: never
       debug: (el?: HTMLElement) => void
       rerender: (props: { name?: string; count?: number }) => Promise<void>
       unmount: () => void
     }>()
+  })
+
+  test('render function accepts and returns wrapper', () => {
+    const result = subject.render(
+      UntypedComponent,
+      {},
+      { wrapper: Component, wrapperProps: { name: 'Alice', count: 42 } }
+    )
+
+    expectTypeOf(result).toExtend<{ wrapper: { hello: string } }>()
+  })
+
+  test('invalid wrapper props are rejected', () => {
+    subject.render(
+      UntypedComponent,
+      {},
+      // @ts-expect-error: count should be a number
+      { wrapper: Component, wrapperProps: { name: 'Alice', count: '42' } }
+    )
   })
 })
 

--- a/tests/render.test-d.ts
+++ b/tests/render.test-d.ts
@@ -3,6 +3,7 @@ import { expectTypeOf } from 'expect-type'
 import { ComponentProps } from 'svelte'
 import { describe, test } from 'vitest'
 
+import UntypedComponent from './fixtures/Comp.svelte'
 import Component from './fixtures/Typed.svelte'
 
 describe('types', () => {
@@ -40,6 +41,7 @@ describe('types', () => {
     expectTypeOf(result).toExtend<{
       container: HTMLElement
       component: { hello: string }
+      wrapper: never
       debug: (el?: HTMLElement) => void
       rerender: (props: { name?: string; count?: number }) => Promise<void>
       unmount: () => void
@@ -54,5 +56,24 @@ describe('types', () => {
     renderSubject({ name: 'Alice', count: 42 })
     // @ts-expect-error: name should be a string
     renderSubject(Component, { name: 42 })
+  })
+
+  test('render function accepts and returns wrapper', () => {
+    const result = subject.render(
+      UntypedComponent,
+      {},
+      { wrapper: Component, wrapperProps: { name: 'Alice', count: 42 } }
+    )
+
+    expectTypeOf(result).toExtend<{ wrapper: { hello: string } }>()
+  })
+
+  test('invalid wrapper props are rejected', () => {
+    subject.render(
+      Component,
+      { name: 'Alice', count: 42 },
+      // @ts-expect-error: count should be a number
+      { wrapper: Component, wrapperProps: { name: 'Alice', count: '42' } }
+    )
   })
 })

--- a/tests/tsconfig.legacy.json
+++ b/tests/tsconfig.legacy.json
@@ -4,6 +4,7 @@
     "render-runes.test-d.ts",
     "fixtures/CompRunes.svelte",
     "fixtures/PropCloner.svelte",
-    "fixtures/TypedRunes.svelte"
+    "fixtures/TypedRunes.svelte",
+    "fixtures/WrapperRunes.svelte"
   ]
 }

--- a/tests/wrapper.test.js
+++ b/tests/wrapper.test.js
@@ -68,7 +68,7 @@ describe('wrapper', () => {
     expect(component.wrappedContext.greeting).toBe('hello')
   })
 
-  test('returns wrapper component instance instance', () => {
+  test('returns wrapper component instance', () => {
     const { wrapper } = render(
       WrappedComp,
       { name: 'world' },

--- a/tests/wrapper.test.js
+++ b/tests/wrapper.test.js
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/svelte'
+import { userEvent } from '@testing-library/user-event'
+import { beforeAll, describe, expect, test } from 'vitest'
+
+import { IS_SVELTE_5, WRAPPER } from './_env.js'
+import WrappedComp from './fixtures/Wrapped.svelte'
+
+describe('wrapper', () => {
+  let Wrapper
+
+  beforeAll(async () => {
+    Wrapper = await import(WRAPPER)
+  })
+
+  test('renders component inside wrapper', () => {
+    render(
+      WrappedComp,
+      { name: 'world', punctuation: '!' },
+      { wrapper: Wrapper, wrapperProps: { greeting: 'hello' } }
+    )
+
+    expect(screen.getByText('hello world!')).toBeInTheDocument()
+  })
+
+  test('rerenders component inside wrapper', async () => {
+    const { rerender } = render(
+      WrappedComp,
+      { name: 'world', punctuation: '!' },
+      { wrapper: Wrapper, wrapperProps: { greeting: 'hello' } }
+    )
+
+    await rerender({ name: 'mundo' })
+
+    expect(screen.getByText('hello mundo!')).toBeInTheDocument()
+  })
+
+  test.runIf(IS_SVELTE_5)('binds props inside wrapper', async () => {
+    const user = userEvent.setup()
+    let value = ''
+
+    render(
+      WrappedComp,
+      {
+        name: '',
+        get value() {
+          return value
+        },
+        set value(nextValue) {
+          value = nextValue
+        },
+      },
+      { wrapper: Wrapper, wrapperProps: { greeting: '' } }
+    )
+
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'hello world')
+
+    expect(value).toBe('hello world')
+  })
+
+  test('returns wrapped component instance', () => {
+    const { component } = render(
+      WrappedComp,
+      { name: 'world' },
+      { wrapper: Wrapper, wrapperProps: { greeting: 'hello' } }
+    )
+
+    expect(component.wrappedContext.greeting).toBe('hello')
+  })
+
+  test('returns wrapper component instance instance', () => {
+    const { wrapper } = render(
+      WrappedComp,
+      { name: 'world' },
+      { wrapper: Wrapper, wrapperProps: { greeting: 'hello' } }
+    )
+
+    expect(wrapper.wrapperContext.greeting).toBe('hello')
+  })
+})


### PR DESCRIPTION
Add a `wrapper` and `wrapperProps` option to `render` in both the `svelte` and `svelte-core` packages. See:

- https://github.com/testing-library/svelte-testing-library/issues/284#issuecomment-2679181737
- https://github.com/vitest-community/vitest-browser-svelte/issues/30